### PR TITLE
feat: serve multiple provisioners from one instance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,12 +87,74 @@ jobs:
           helm lint "$chart"
           helm lint "$chart" --set commonLabels.team=platform
           helm lint "$chart" --set commonAnnotations.owner=infra
+          # The deprecated single-provider form, exactly as a 0.2.x values file
+          # would express it: the old scalars and NO mention of providers.
           helm lint "$chart" \
             --set commonLabels.a=b \
             --set commonAnnotations.c=d \
             --set labelPrefix=example.com/ \
             --set secretNamePattern='vc-*' \
             --set secretKey=config
+          # Several presets at once, which is the point of 0.3.0.
+          helm lint "$chart" \
+            --set 'providers[0]=k3k' \
+            --set 'providers[1]=kamaji' \
+            --set 'providers[2]=capi'
+          # A custom shape spelled out in full, including a multi-key list.
+          helm lint "$chart" \
+            --set 'providers[0]=k3k' \
+            --set 'providers[1].name=mytool' \
+            --set 'providers[1].secretNamePattern=mytool-*-kubeconfig' \
+            --set 'providers[1].secretKeys={admin.conf,admin.svc}'
+
+      # A 0.2.x values file sets the old scalars and says nothing about
+      # `providers`. Helm still coalesces the chart default in, so if that default
+      # is non-empty the legacy branch is unreachable and the user's settings are
+      # dropped without a word: the pod looks healthy and registers nothing. This
+      # is the regression test for that.
+      - name: A 0.2.x values file still renders the deprecated flags
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          cat <<'EOF' > /tmp/legacy-values.yaml
+          secretNamePattern: "vc-*"
+          secretKey: config
+          EOF
+          out=$(helm template t "$chart" -f /tmp/legacy-values.yaml)
+          grep -q -- "--secret-name-pattern=vc-\*" <<<"$out" || {
+            echo "::error::a 0.2.x values file no longer renders its own settings"
+            grep -- '--' <<<"$out"; exit 1
+          }
+          grep -q -- '--secret-key=config' <<<"$out"
+          if grep -q -- '--provider=' <<<"$out"; then
+            echo "::error::chart injected a default provider over the user's legacy settings"
+            exit 1
+          fi
+
+      # Setting both forms is ambiguous, and quietly honouring either one is how an
+      # upgrade ends up looking healthy while registering nothing. The chart must
+      # fail rather than choose.
+      - name: Setting both provider forms fails the render
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          if helm template t "$chart" --set 'providers[0]=k3k' \
+               --set secretNamePattern='vc-*' --set secretKey=config >/dev/null 2>&1; then
+            echo "::error::chart rendered with both provider forms set; it must fail"
+            exit 1
+          fi
+
+      # With neither set, the chart must emit no provider flags at all and let the
+      # binary apply its own default. Emitting one here is what broke the case above.
+      - name: A default install emits no provider flags
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          out=$(helm template t "$chart")
+          if grep -qE -- '--provider=|--secret-name-pattern=|--secret-key=' <<<"$out"; then
+            echo "::error::default install should defer to the binary's own default"
+            grep -- '--' <<<"$out"; exit 1
+          fi
 
   deploy-test:
     needs: [lint, test]
@@ -122,13 +184,15 @@ jobs:
           kind load docker-image "$img" --name chart-testing
           echo "ref=$img" >> "$GITHUB_OUTPUT"
 
-      # A synthetic child: a labelled namespace holding a kubeconfig Secret in
-      # the shape k3k produces. This exercises the real contract without waiting
-      # on a provisioner to boot.
-      - name: Seed a fake child cluster
+      # Two synthetic children in DIFFERENT shapes: one as k3k writes it, one as
+      # the Cluster API contract requires. This exercises the real contract
+      # without waiting on a provisioner to boot, and proves a single instance
+      # serves a mixed fleet -- which was impossible before 0.3.0.
+      - name: Seed fake child clusters
         run: |
           set -euo pipefail
           kubectl create namespace argocd
+
           kubectl create namespace k3k-sandbox
           kubectl label namespace k3k-sandbox \
             argocd-cluster-registrar/managed-by=cluster-registrar \
@@ -150,6 +214,35 @@ jobs:
           kubectl create secret generic k3k-sandbox-kubeconfig \
             -n k3k-sandbox --from-file=kubeconfig.yaml=/tmp/kubeconfig.yaml
 
+          # CAPI shape: `<cluster>-kubeconfig`, key `value`, multiple entries
+          # with an explicit current-context.
+          kubectl create namespace capi-child
+          kubectl label namespace capi-child \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=capichild
+          cat <<'EOF' > /tmp/value
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - name: capichild
+            cluster:
+              server: https://192.0.2.20
+              certificate-authority-data: Y2FkYXRh
+          users:
+          - name: capichild-admin
+            user:
+              client-certificate-data: Y2VydGRhdGE=
+              client-key-data: a2V5ZGF0YQ==
+          contexts:
+          - name: capichild-admin@capichild
+            context:
+              cluster: capichild
+              user: capichild-admin
+          current-context: capichild-admin@capichild
+          EOF
+          kubectl create secret generic capichild-kubeconfig \
+            -n capi-child --from-file=value=/tmp/value
+
       - name: Install the chart
         run: |
           set -euo pipefail
@@ -158,38 +251,87 @@ jobs:
             --set image.repository="$(echo '${{ steps.image.outputs.ref }}' | cut -d: -f1)" \
             --set image.tag="$(echo '${{ steps.image.outputs.ref }}' | cut -d: -f2)" \
             --set image.pullPolicy=IfNotPresent \
+            --set 'providers[0]=k3k' \
+            --set 'providers[1]=capi' \
             --set interval=5s \
             --wait --timeout 3m
 
       # Assertions are real: no `|| echo "Ignored..."`, so a regression fails CI.
-      - name: It registers the cluster
+      - name: It registers both shapes, under one instance
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
-            if kubectl get secret cluster-sandbox -n argocd >/dev/null 2>&1; then
-              echo "registered after ${i}0s"
-              kubectl get secret cluster-sandbox -n argocd \
-                -o jsonpath='{.metadata.labels}'; echo
+            if kubectl get secret cluster-sandbox -n argocd >/dev/null 2>&1 \
+               && kubectl get secret cluster-capichild -n argocd >/dev/null 2>&1; then
+              echo "both registered after ${i}0s"
+              kubectl get secret cluster-sandbox -n argocd -o jsonpath='{.metadata.labels}'; echo
+              kubectl get secret cluster-capichild -n argocd -o jsonpath='{.metadata.labels}'; echo
               test "$(kubectl get secret cluster-sandbox -n argocd -o jsonpath='{.data.server}' | base64 -d)" = "https://192.0.2.10"
+              test "$(kubectl get secret cluster-capichild -n argocd -o jsonpath='{.data.server}' | base64 -d)" = "https://192.0.2.20"
+              # The provider label is what makes a mixed fleet introspectable.
+              test "$(kubectl get secret cluster-sandbox -n argocd -o jsonpath='{.metadata.labels.argocd-cluster-registrar/provider}')" = "k3k"
+              test "$(kubectl get secret cluster-capichild -n argocd -o jsonpath='{.metadata.labels.argocd-cluster-registrar/provider}')" = "capi"
               exit 0
             fi
             sleep 10
           done
-          echo "::error::cluster-sandbox was never created"
+          echo "::error::both cluster Secrets were never created"
+          kubectl get secrets -n argocd
           kubectl logs -n registrar deploy/registrar-argocd-cluster-registrar --tail=50
           exit 1
 
-      - name: It deregisters when the source namespace is gone
+      # Collection must be per-cluster. Deleting one child must not disturb the
+      # other, and -- before 0.3.0 -- one unevaluable namespace suppressed GC for
+      # the entire fleet.
+      - name: It deregisters only the cluster whose namespace is gone
         run: |
           set -euo pipefail
           kubectl delete namespace k3k-sandbox --wait=true
           for i in $(seq 1 30); do
             if ! kubectl get secret cluster-sandbox -n argocd >/dev/null 2>&1; then
               echo "deregistered after ${i}0s"
+              if ! kubectl get secret cluster-capichild -n argocd >/dev/null 2>&1; then
+                echo "::error::cluster-capichild was collected too; GC is not per-cluster"
+                exit 1
+              fi
               exit 0
             fi
             sleep 10
           done
           echo "::error::cluster-sandbox was never garbage collected"
+          kubectl logs -n registrar deploy/registrar-argocd-cluster-registrar --tail=50
+          exit 1
+
+      # A Secret that matches the shape but does not parse must never look like a
+      # deletion, and must not stop OTHER clusters being collected. A starting k3k
+      # child is in exactly this state for roughly its first ninety seconds.
+      - name: A half-written kubeconfig neither deregisters nor blocks GC
+        run: |
+          set -euo pipefail
+          kubectl create namespace k3k-broken
+          kubectl label namespace k3k-broken \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=broken
+          printf '<html>not a kubeconfig</html>' > /tmp/broken
+          kubectl create secret generic k3k-broken-kubeconfig \
+            -n k3k-broken --from-file=kubeconfig.yaml=/tmp/broken
+          sleep 20
+          if kubectl get secret cluster-broken -n argocd >/dev/null 2>&1; then
+            echo "::error::an unparseable kubeconfig was registered"
+            exit 1
+          fi
+          # The still-healthy child must remain registered throughout.
+          kubectl get secret cluster-capichild -n argocd >/dev/null
+
+          # ...and GC must still work for everything else while it is stuck.
+          kubectl delete namespace capi-child --wait=true
+          for i in $(seq 1 24); do
+            if ! kubectl get secret cluster-capichild -n argocd >/dev/null 2>&1; then
+              echo "collected despite a stuck namespace, after ${i}0s"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::a stuck namespace suppressed garbage collection for the fleet"
           kubectl logs -n registrar deploy/registrar-argocd-cluster-registrar --tail=50
           exit 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,7 +72,7 @@ kos:
       # Not {{.GitURL}}: that yields the SSH remote, which GHCR will not link.
       org.opencontainers.image.source: "https://github.com/pcanilho/argocd-cluster-registrar"
       org.opencontainers.image.licenses: "Apache-2.0"
-      org.opencontainers.image.description: "Registers k3k and vcluster child clusters with ArgoCD, and removes them when they are deleted"
+      org.opencontainers.image.description: "Registers the clusters you run inside your cluster with ArgoCD, and removes them again when they are deleted"
     bare: true
     preserve_import_paths: false
     tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,90 @@ All notable changes to **argocd-cluster-registrar** are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-07
+
+Serves more than one provisioner at a time. Until now `Config` held a single
+secret-name pattern and a single key, so an instance could register k3k **or**
+vcluster and never both. The obvious workaround, a second Deployment, is a
+trap: two instances sharing a `managedBy` value garbage collect each other's
+Secrets.
+
+Adds Kamaji and the Cluster API contract alongside the existing two, and fixes
+two pre-existing defects found while making room for them.
+
+Backwards compatible: a `0.2.x` values file keeps working unchanged. `providers`
+ships **empty** so that a values file which sets only the deprecated
+`secretNamePattern`/`secretKey` still takes the legacy path. Setting both forms is
+now a chart-render failure rather than a silent preference for one.
+
+### Added
+
+- `providers`, a list of provisioner shapes tried in precedence order, replacing
+  the single `secretNamePattern`/`secretKey` pair. Presets ship for `k3k`,
+  `vcluster`, `kamaji` and `capi`; a custom shape can be given in full as
+  `{name, secretNamePattern, secretKeys}`.
+- **Kamaji**: `*-admin-kubeconfig`, keys `admin.conf` or `admin.svc`. Two keys,
+  because Kamaji switches to `admin.svc` when its control plane advertises a
+  service address. Verified against Kamaji v1.0.0: a real `TenantControlPlane`
+  registered, and the resulting credentials authenticated to the tenant API server
+  with full x509 verification. The same `Secret` also carries `super-admin.conf`,
+  which is deliberately not preferred.
+- **Cluster API**: `*-kubeconfig`, key `value`. A mandatory control-plane contract
+  rather than a convention, so the one entry covers any CAPI cluster whatever the
+  infrastructure provider, plus standalone k0smotron, which adopts the same shape.
+  Scoped to self-managed control planes: CAPA/CAPZ/CAPG hand out exec credentials,
+  which cannot become an ArgoCD Secret at all, or ~15-minute tokens, which can and
+  then quietly expire.
+- `<labelPrefix>provider` on each cluster Secret, recording which provider
+  matched, so an ApplicationSet can select by provisioner. This makes the first
+  pass after upgrade rewrite every existing registration: the label is new,
+  nothing else about them changes.
+- Candidate fallthrough. A Secret matching a provider's shape but failing to parse
+  no longer poisons the namespace; the next candidate is tried. That is what makes
+  CAPA's `<cluster>-user-kubeconfig` decoy harmless, rather than leaving the
+  outcome to depend on `k` sorting before `u`.
+- Validation for duplicate provider names, and a test for the empty-pattern case
+  the code has always checked but nothing exercised.
+
+### Fixed
+
+- **Garbage collection is no longer suppressed fleet-wide by one bad namespace.**
+  Any managed namespace without a usable kubeconfig cleared a single `complete`
+  flag, which skipped `collect()` entirely, so one permanently broken namespace
+  kept every other cluster's dead registration in ArgoCD indefinitely. Every k3k
+  child hits this for its first ~90 seconds, during which GC was off for the whole
+  fleet. Unevaluable namespaces are now exempted individually, and everything else
+  is collected normally.
+
+  One consequence worth knowing: if a cluster **moves namespaces**, the old
+  namespace is provably gone while the new one is still unresolved, so the
+  registration is now deleted and re-created a pass or two later. Applications
+  targeting it can go briefly Unknown. Under the old fleet-wide flag there was no
+  gap, because nothing was collected at all.
+- **Reserved labels can no longer be spoofed from a source namespace.** Propagated
+  labels are copied over the ones the tool computes, and `source-namespace` was
+  not withheld, so a namespace labelling itself
+  `<prefix>source-namespace: kube-system` produced a registration whose GC proof
+  pointed at a namespace that never disappears, making it permanently
+  uncollectable. All reserved suffixes are now withheld.
+
+### Changed
+
+- `--secret-name-pattern` and `--secret-key` are deprecated in favour of
+  `--provider`, and kept as a single-provider shorthand. They cannot be combined
+  with `--provider`; the binary rejects that rather than silently preferring one.
+  The chart renders one form or the other, never both. Passing both is
+  indistinguishable from meaning both, which is how a stale values file ends up
+  quietly ignoring `providers`.
+- The tagline, chart description, image description and `--help` text no longer
+  enumerate k3k and vcluster, which stopped being accurate at four provisioners.
+  The chart `keywords` still name them, deliberately, since that is what people
+  search for. The provisioner table carries the specifics and keeps an honest
+  `Status` column: `tested` means run against the real thing, `assumed` means
+  taken from upstream source but not exercised here.
+- README's RBAC section corrected. It claimed Secret writes were cluster-scoped;
+  they have been a namespaced Role bound to `targetNamespace` since 0.2.0.
+
 ## [0.2.0] - 2026-08-06
 
 Renames the project from `vcluster-argocd-exporter` and rewrites it as a

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <br>
     <i><b>argocd-cluster-registrar</b></i>
     <br>
-    Registers <a href="https://github.com/rancher/k3k">k3k</a> and <a href="https://www.vcluster.com/">vcluster</a> child clusters with ArgoCD, and removes them again when they are deleted
+    A cluster registrar made for ArgoCD
     <br>
     <br>
     ⚙️ <a href="#installing">Installing</a> | 🔎 <a href="#configuring">Configuring</a> | 🧩 <a href="#how-it-works">How it works</a>
@@ -19,13 +19,20 @@
     <br>
 </p>
 
-You spin up a cluster inside your cluster with [k3k](https://github.com/rancher/k3k)
-or [vcluster](https://www.vcluster.com/), and ArgoCD cannot see it. The provisioner
-writes a kubeconfig `Secret` into the cluster's namespace, but ArgoCD only reads
-`Secret`s in its own namespace labelled `argocd.argoproj.io/secret-type: cluster`.
-So you end up registering clusters by hand, or with a script.
+If you are running clusters inside your cluster with
+[k3k](https://github.com/rancher/k3k), [vcluster](https://www.vcluster.com/),
+[Kamaji](https://kamaji.clastix.io/) or [Cluster API](https://cluster-api.sigs.k8s.io/),
+and you use [ArgoCD](https://argoproj.github.io/argo-cd/), stop reading and jump to
+[installing](#installing)!
 
-This does it for you, and it also does the part scripts usually skip:
+Why? You have probably noticed that ArgoCD does not detect them out-of-the-box. The
+provisioner writes a kubeconfig `Secret` into the cluster's namespace, but ArgoCD only
+reads `Secret`s in its own namespace labelled
+`argocd.argoproj.io/secret-type: cluster`, so you end up registering clusters by hand,
+or with a somewhat painful ad-hoc script.
+
+I have got you covered. This does it for you, and it also does the part scripts
+usually skip:
 
 * Registers each child cluster it finds, so ArgoCD can target it by name.
 * Deletes the registration when the cluster is gone. Otherwise a destroyed
@@ -37,13 +44,16 @@ This does it for you, and it also does the part scripts usually skip:
 > [!IMPORTANT]
 > Upgrading from `0.1.x` (`vcluster-argocd-exporter`)? The flags, values, Secret
 > names and labels all changed, and a stale values file fails silently. See
-> [Migrating from 0.1.x](CHANGELOG.md#migrating-from-01x).
+> [Migrating from 0.1.x](CHANGELOG.md#migrating-from-01x). That section predates
+> `providers`; where it tells you to set `secretNamePattern`/`secretKey`, prefer a
+> `providers` entry instead.
 
 ## Installing
 
 Install it once, as a singleton. Do not add it as a dependency of a per-cluster
 chart: every instance reconciles cluster-wide and garbage collects, so two
-instances sharing a `managedBy` value will delete each other's `Secret`s.
+instances sharing a `managedBy` value fight over the same `Secret`s, each
+overwriting the other's work every pass.
 
 ### Helm `dependency`
 
@@ -79,10 +89,9 @@ labelPrefix: argocd-cluster-registrar/
 # watch, and which cluster Secrets this release owns. Give each instance its own.
 managedBy: cluster-registrar
 
-# Glob matching the kubeconfig Secret in a watched namespace, and the key inside
-# it. The defaults suit k3k.
-secretNamePattern: "k3k-*-kubeconfig"
-secretKey: kubeconfig.yaml
+# Provisioners to look for, in precedence order. Presets: k3k, vcluster, kamaji,
+# capi. Empty means the binary's own default, which is k3k. See "Providers" below.
+providers: []
 
 # Each pass re-reads every kubeconfig, which is what keeps registrations working
 # after a certificate rotation.
@@ -103,15 +112,110 @@ cluster, so you can try it before installing anything:
 argocd-cluster-registrar --once --dry-run --debug
 ```
 
-### Settings per provisioner
+### Providers
 
-| Provisioner | `secretNamePattern` | `secretKey` | Status |
-|---|---|---|---|
-| [k3k](https://github.com/rancher/k3k) v1.2.0-rc3 | `k3k-*-kubeconfig` | `kubeconfig.yaml` | tested |
-| [vcluster](https://www.vcluster.com/) 0.36.1 | `vc-*` | `config` | tested, see below |
+`providers` lists the provisioner shapes to look for, **in precedence order**.
+Each preset is a `Secret`-name glob plus the keys that may hold the kubeconfig:
 
-Anything else that writes a kubeconfig into a `Secret` should work by setting
-those two values, but only the two above have actually been run.
+| Preset | Provisioner | `Secret` name | Key(s) | Status |
+|---|---|---|---|---|
+| `k3k` | [k3k](https://github.com/rancher/k3k) v1.2.0-rc3 | `k3k-*-kubeconfig` | `kubeconfig.yaml` | tested |
+| `vcluster` | [vcluster](https://www.vcluster.com/) 0.36.1 | `vc-*` | `config` | tested, see below |
+| `kamaji` | [Kamaji](https://kamaji.clastix.io/) v1.0.0 standalone | `*-admin-kubeconfig` | `admin.conf`, `admin.svc` | tested, see below |
+| `capi` | [Cluster API](https://cluster-api.sigs.k8s.io/) contract | `*-kubeconfig` | `value` | assumed |
+
+`Status` is meant literally: **tested** has been run against the real thing,
+**assumed** was taken from upstream source but not exercised here.
+
+Several can run at once, which is rather the point. One instance serves a mixed
+fleet:
+
+```yaml
+providers:
+  - k3k
+  - capi
+```
+
+Anything else that writes a kubeconfig into a `Secret` works too, spelled out in
+full:
+
+```yaml
+providers:
+  - name: mytool
+    secretNamePattern: "mytool-*-kubeconfig"
+    secretKeys: [kubeconfig]
+```
+
+The matched provider is recorded on the cluster `Secret` as
+`<labelPrefix>provider`, so an ApplicationSet can select by provisioner.
+
+#### Scope
+
+This registers clusters **provisioned inside the host cluster**: something running
+here writes a kubeconfig `Secret` into a namespace you can label, and that `Secret`
+is the only input. A standalone cluster elsewhere has no such object, so there is
+nothing to discover. That is a different problem, usually one of reachability.
+
+#### Why order matters
+
+The globs overlap deliberately. `capi`'s `*-kubeconfig` also matches k3k's
+`k3k-<cluster>-kubeconfig`. Correctness comes from the **key**, not the name: the
+k3k `Secret` carries no `value`, so `capi` falls through. Where two providers could
+both claim a `Secret`, the one declared first wins, and a `Secret` already claimed
+is never offered twice, so one cluster is registered once.
+
+That is not hypothetical. Driving Kamaji through its Cluster API control-plane
+provider produces **two** `Secret`s for one cluster: Kamaji's own
+`<tcp>-admin-kubeconfig`, and a CAPI-shaped `<cluster>-kubeconfig` copied from it.
+With both presets enabled, both match.
+
+#### Kamaji
+
+Tested against Kamaji v1.0.0: a `TenantControlPlane` named `tenant-00` produced
+`tenant-00-admin-kubeconfig`, and the resulting registration authenticated to the
+tenant API server with `insecure: false` and full x509 verification.
+
+Two things worth knowing. The `Secret` also carries `super-admin.conf` and
+`super-admin.svc`; the preset tries `admin.conf` first, so the ordinary admin
+credential wins and the more privileged one is never copied. And Kamaji writes
+sibling `<tcp>-controller-manager-kubeconfig` and `<tcp>-scheduler-kubeconfig`
+`Secret`s, which do **not** end in `-admin-kubeconfig` and so never match the
+`kamaji` preset. They do match `capi`'s looser `*-kubeconfig`, but carry no
+`value` key, so they are rejected there too.
+
+`admin.conf` points at the control plane's `Service` address. When
+`spec.networkProfile.address` advertises a different one, Kamaji writes it to
+`admin.svc` as well, hence two keys. Both are normally present at once: a live
+v1.0.0 `TenantControlPlane` carried `admin.conf`, `admin.svc`, `super-admin.conf`
+and `super-admin.svc` on the same `Secret`.
+
+Whichever key is present first in the list wins, and only that one is tried. If
+`admin.conf` is unusable, `admin.svc` is not attempted as a fallback; reorder them
+in a custom provider entry if you need the other.
+
+#### About `capi`
+
+It is the *mandatory* Cluster API control-plane contract rather than a convention:
+`<cluster>-kubeconfig` in the Cluster's namespace, type `cluster.x-k8s.io/secret`,
+kubeconfig under `value`. One entry therefore covers any CAPI cluster whatever the
+**infrastructure** provider. Note that the kubeconfig is written by the
+*control-plane* provider (KCP, KamajiControlPlane, K0sControlPlane,
+KThreesControlPlane, Talos CACPPT), not by CAPD, Proxmox or Metal3. Standalone
+k0smotron adopts the same shape, so it is covered as well.
+[CAPI + KubeVirt](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt)
+is the closest peer to k3k and vcluster: child clusters as VMs inside the host
+cluster.
+
+It does **not** usefully cover managed cloud control planes. CAPA's EKS path writes
+a second `<cluster>-user-kubeconfig` holding an `exec` credential, which cannot be
+copied into an ArgoCD `Secret` at all, and the CAPI-internal one holds a token that
+rotates every ~15 minutes. A candidate that fails to parse is skipped in favour of
+the next, so the `exec` case degrades safely. A short-lived token is worse: it
+parses, registers, and then quietly expires. So
+treat `capi` as self-managed control planes only.
+
+`capi` is also the loosest pattern shipped: `*-kubeconfig` matches anything in a
+managed namespace ending that way. Put a more specific provider first.
 
 #### vcluster
 
@@ -141,9 +245,11 @@ controlPlane:
 ```
 
 Note that `vc-*` also matches vcluster's own `vc-config-<name>` `Secret`, which
-holds no kubeconfig. That is handled: a `Secret` is only used if it matches the
-name pattern *and* carries `secretKey`. Do not rely on ordering to save you here
-(`vc-config-abc` sorts before `vc-abc`, but after `vc-xyz`).
+holds no kubeconfig (its key is `config.yaml`, not `config`). That is handled: a
+`Secret` is only used if it matches the name pattern *and* carries one of the
+provider's keys. Do not rely on ordering to save you here: whether the decoy sorts
+first depends entirely on the names. `vc-config-x` sorts before `vc-x`, but
+`vc-config-abc` sorts *after* `vc-abc`. The key check is what saves you, not the sort.
 
 ### Marking a cluster for registration
 
@@ -223,6 +329,9 @@ Cluster `Secret`s that carry the ownership label but whose source namespace has
 gone are deleted. Anything without that label is left alone, so clusters you
 registered by hand are safe.
 
-RBAC is `namespaces` (read) and `secrets` (read, write, delete). It is
-cluster-scoped because the sources sit in one namespace per child while the
-destination sits in `argocd`.
+RBAC is split by scope. Reads are cluster-wide (`namespaces` get/list, `secrets`
+list) because discovery is label-driven and the sources sit in one namespace per
+child. Every **write** is a namespaced `Role` bound to
+`targetNamespace` alone, since that is the only place this ever creates, updates
+or deletes anything. Granting `secrets` write across the whole cluster would be a
+privilege-escalation path in exchange for nothing.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -31,10 +32,53 @@ var (
 	interval          time.Duration
 	targetNamespace   string
 	managedByValue    string
+	providerSpecs     []string
 	secretNamePattern string
 	secretKey         string
 	labelPrefix       string
 )
+
+// resolveProviders turns the flags into the provider list, honouring the
+// pre-0.3.0 single-provider flags.
+//
+// The gate is `Changed`, NOT emptiness, and that distinction is the whole point:
+// --secret-name-pattern and --secret-key both carry non-empty defaults, so they
+// are never unset. Testing them for "" would take the legacy branch every single
+// time and silently ignore --provider entirely -- the same class of quiet
+// misconfiguration the 0.1.x migration note warns about, which is precisely what
+// this compatibility path exists to avoid.
+func resolveProviders(cmd *cobra.Command) ([]registrar.Provider, error) {
+	legacy := cmd.Flags().Changed("secret-name-pattern") || cmd.Flags().Changed("secret-key")
+
+	if len(providerSpecs) > 0 {
+		if legacy {
+			return nil, fmt.Errorf(
+				"--provider cannot be combined with --secret-name-pattern/--secret-key; " +
+					"express the old flags as a provider spec instead")
+		}
+		out := make([]registrar.Provider, 0, len(providerSpecs))
+		for _, spec := range providerSpecs {
+			p, err := registrar.ParseProvider(spec)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, p)
+		}
+		return out, nil
+	}
+
+	if legacy {
+		return []registrar.Provider{{
+			Name:              "custom",
+			SecretNamePattern: secretNamePattern,
+			SecretKeys:        []string{secretKey},
+		}}, nil
+	}
+
+	// Neither set: the shipped default, unchanged from 0.2.x.
+	p, _ := registrar.Preset("k3k")
+	return []registrar.Provider{p}, nil
+}
 
 var rootCmd = &cobra.Command{
 	Use:     "cluster-registrar",
@@ -43,17 +87,17 @@ var rootCmd = &cobra.Command{
 	Long: `Reconciles child-cluster kubeconfig Secrets into ArgoCD cluster Secrets.
 
 Discovery is namespace-driven: any namespace labelled
-` + registrar.ManagedByLabel(registrar.DefaultLabelPrefix) + `=<value> is inspected for a Secret matching
---secret-name-pattern, whose kubeconfig is reshaped into an ArgoCD cluster
-Secret in --target-namespace.
+` + registrar.ManagedByLabel(registrar.DefaultLabelPrefix) + `=<value> is inspected for a Secret
+matching one of the configured --provider shapes, whose kubeconfig is reshaped
+into an ArgoCD cluster Secret in --target-namespace.
 
 That indirection exists because the provisioner -- not this tool -- creates the
 kubeconfig Secret, so it carries none of our labels. The namespace is the
 nearest object we control, so per-cluster intent lives there.
 
-Nothing here is vcluster-specific: k3k, plain k3s and CAPI-style providers all
-publish a kubeconfig Secret, and any of them work by adjusting the pattern and
-key.
+The tool is provisioner-neutral. Anything that writes a kubeconfig into a Secret
+works; presets ship for ` + strings.Join(registrar.PresetNames(), ", ") + `, and --provider takes several at
+once so one instance can serve a mixed fleet.
 
 Secrets whose source namespace has gone away are DELETED, so a destroyed cluster
 does not leave a broken entry behind in ArgoCD.`,
@@ -73,13 +117,17 @@ does not leave a broken entry behind in ArgoCD.`,
 			return fmt.Errorf("--interval must be positive, got %s", interval)
 		}
 
+		providers, err := resolveProviders(cmd)
+		if err != nil {
+			return err
+		}
+
 		cfg := registrar.Config{
-			TargetNamespace:   targetNamespace,
-			ManagedByValue:    managedByValue,
-			SecretNamePattern: secretNamePattern,
-			SecretKey:         secretKey,
-			LabelPrefix:       labelPrefix,
-			DryRun:            dryRun,
+			TargetNamespace: targetNamespace,
+			ManagedByValue:  managedByValue,
+			Providers:       providers,
+			LabelPrefix:     labelPrefix,
+			DryRun:          dryRun,
 		}
 		if err := cfg.Validate(); err != nil {
 			return err
@@ -97,11 +145,19 @@ does not leave a broken entry behind in ArgoCD.`,
 			return r.Reconcile(ctx)
 		}
 
+		// Report the providers actually in force, not the deprecated flag's
+		// default. This line is the only startup evidence of what the process is
+		// looking for, and logging `secretNamePattern` meant it always announced
+		// `k3k-*-kubeconfig` no matter what --provider was set to.
+		names := make([]string, 0, len(providers))
+		for _, p := range providers {
+			names = append(names, p.Name)
+		}
 		log.Info("starting reconcile loop",
 			slog.Duration("interval", interval),
 			slog.String("targetNamespace", targetNamespace),
 			slog.String("managedBy", managedByValue),
-			slog.String("secretNamePattern", secretNamePattern))
+			slog.String("providers", strings.Join(names, ",")))
 
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -139,10 +195,18 @@ func init() {
 		"namespace ArgoCD reads cluster Secrets from")
 	f.StringVar(&managedByValue, "managed-by", "cluster-registrar",
 		"value of the <label-prefix>managed-by label identifying namespaces to watch and Secrets to own")
+	// StringArray, not StringSlice: a custom spec's key list is comma-separated,
+	// and StringSlice would split it into separate providers.
+	f.StringArrayVar(&providerSpecs, "provider", nil,
+		"provisioner to look for; repeatable. One of "+strings.Join(registrar.PresetNames(), ", ")+
+			", or a custom \"name=pattern=key[,key...]\". Defaults to k3k")
+	// Superseded by --provider, kept so a 0.2.x values file keeps working. Note
+	// these defaults are never empty, which is why resolveProviders gates on
+	// Changed() rather than on the values.
 	f.StringVar(&secretNamePattern, "secret-name-pattern", "k3k-*-kubeconfig",
-		"glob matching the kubeconfig Secret within a watched namespace")
+		"DEPRECATED, use --provider: glob matching the kubeconfig Secret within a watched namespace")
 	f.StringVar(&secretKey, "secret-key", "kubeconfig.yaml",
-		"key inside that Secret holding the kubeconfig")
+		"DEPRECATED, use --provider: key inside that Secret holding the kubeconfig")
 	f.StringVar(&labelPrefix, "label-prefix", registrar.DefaultLabelPrefix,
 		"prefix for the labels read from the source namespace and copied onto the cluster Secret")
 }

--- a/deploy/charts/argocd-cluster-registrar/Chart.yaml
+++ b/deploy/charts/argocd-cluster-registrar/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: argocd-cluster-registrar
-description: Registers k3k and vcluster child clusters with ArgoCD, and removes them when they are deleted
+description: Registers the clusters you run inside your cluster with ArgoCD, and removes them again when they are deleted
 
 type: application
 version: 0.2.0
@@ -14,9 +14,13 @@ icon: https://raw.githubusercontent.com/pcanilho/argocd-cluster-registrar/main/d
 keywords:
   - argocd
   - gitops
+  - multi-cluster
+  - multi-tenancy
+  - virtual-cluster
+  - cluster-api
   - k3k
   - vcluster
-  - multi-cluster
+  - kamaji
   - kubernetes
 
 maintainers:

--- a/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
+++ b/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
@@ -48,8 +48,31 @@ spec:
             - "--target-namespace={{ .Values.targetNamespace }}"
             - "--label-prefix={{ .Values.labelPrefix }}"
             - "--managed-by={{ .Values.managedBy }}"
-            - "--secret-name-pattern={{ .Values.secretNamePattern }}"
-            - "--secret-key={{ .Values.secretKey }}"
+            {{- /*
+              Emit EITHER the provider list OR the pre-0.3.0 scalars, never both.
+
+              Setting both is a hard failure rather than a silent preference. Once
+              two ways to say the same thing exist, quietly honouring one of them
+              is how an upgrade ends up looking healthy while registering nothing:
+              the operator sees their values in git, and the pod is hunting for
+              something else entirely. `providers` is empty by default precisely so
+              that "set" can be told apart from "defaulted" here.
+            */}}
+            {{- if and .Values.providers (or .Values.secretNamePattern .Values.secretKey) }}
+            {{- fail "providers and secretNamePattern/secretKey are mutually exclusive. secretNamePattern/secretKey are deprecated; express them as a providers entry instead, e.g. providers: [{name: custom, secretNamePattern: 'vc-*', secretKeys: [config]}]" }}
+            {{- end }}
+            {{- if .Values.providers }}
+            {{- range .Values.providers }}
+            {{- if kindIs "string" . }}
+            - "--provider={{ . }}"
+            {{- else }}
+            - "--provider={{ .name }}={{ .secretNamePattern }}={{ join "," .secretKeys }}"
+            {{- end }}
+            {{- end }}
+            {{- else if or .Values.secretNamePattern .Values.secretKey }}
+            - "--secret-name-pattern={{ required "secretNamePattern is required when secretKey is set" .Values.secretNamePattern }}"
+            - "--secret-key={{ required "secretKey is required when secretNamePattern is set" .Values.secretKey }}"
+            {{- end }}
             - "--interval={{ .Values.interval }}"
             {{- if .Values.dryRun }}
             - --dry-run

--- a/deploy/charts/argocd-cluster-registrar/values.yaml
+++ b/deploy/charts/argocd-cluster-registrar/values.yaml
@@ -12,15 +12,44 @@ labelPrefix: argocd-cluster-registrar/
 # pointed at the same value would fight over the same Secrets; give each its own.
 managedBy: cluster-registrar
 
-# Glob matching the kubeconfig Secret inside a watched namespace, and the key
-# within it. Defaults suit k3k, which names it `k3k-<cluster>-kubeconfig` with the
-# kubeconfig under `kubeconfig.yaml`.
+# Provisioners to look for, in precedence order. Order matters, because the
+# patterns legitimately overlap: `capi` matches `*-kubeconfig`, which includes
+# k3k's Secret. Correctness comes from the key, not the name.
 #
-# Matching by name rather than label is deliberate: the provisioner creates that
-# Secret, so it carries none of our labels. Adjust these two for a different
-# provisioner -- CAPI uses `<cluster>-kubeconfig` with the key `value`.
-secretNamePattern: "k3k-*-kubeconfig"
-secretKey: kubeconfig.yaml
+# Built-in presets: k3k, vcluster, kamaji, capi. A custom shape can be spelled
+# out in full instead:
+#
+#   providers:
+#     - k3k
+#     - name: mytool
+#       secretNamePattern: "mytool-*-kubeconfig"
+#       secretKeys: [kubeconfig]
+#
+# Matching by name rather than by label is deliberate: the provisioner creates
+# that Secret, so it carries none of our labels and there is nowhere to add them.
+#
+# On `capi`: it is the MANDATORY Cluster API control-plane contract
+# (`<cluster>-kubeconfig`, key `value`), so one entry covers any CAPI cluster
+# whatever the infrastructure provider, plus standalone k0smotron. It does not
+# usefully cover managed cloud control planes -- CAPA/CAPZ/CAPG hand out exec
+# credentials, which cannot be copied into an ArgoCD cluster Secret at all, or
+# short-lived tokens, which can but then expire.
+#
+# EMPTY BY DEFAULT, and that is load-bearing rather than an oversight. Helm
+# coalesces chart defaults into every user's values, so a non-empty default here
+# would be indistinguishable from a deliberate setting: a 0.2.x values file that
+# sets only `secretNamePattern`/`secretKey` and never mentions `providers` would
+# still take the branch below and have those two silently ignored. Leaving this
+# empty lets the binary supply the default instead, where it can tell "unset"
+# from "set to k3k". Unset, the binary uses `k3k`.
+providers: []
+
+# Superseded by `providers`, kept so a 0.2.x values file keeps working unchanged.
+# Set BOTH or neither. If `providers` is also set the chart fails rather than
+# guessing, because preferring either one silently is how an upgrade quietly
+# stops registering anything.
+secretNamePattern: ""
+secretKey: ""
 
 # How often to reconcile. Each pass re-reads every kubeconfig, which is what
 # keeps registrations valid across a k3s server restart -- those rotate the client

--- a/internal/registrar/kubeconfig_test.go
+++ b/internal/registrar/kubeconfig_test.go
@@ -61,6 +61,98 @@ users:
     client-key-data: a2V5ZGF0YQ==
 `
 
+// Kamaji's standalone `<tcp>-admin-kubeconfig` Secret, key `admin.conf`. kubeadm
+// shapes it, so the names are the kubeadm ones rather than the cluster's.
+const kamajiKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: tenant-00
+  cluster:
+    server: https://192.168.1.195:6443
+    certificate-authority-data: Y2FkYXRh
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data: Y2VydGRhdGE=
+    client-key-data: a2V5ZGF0YQ==
+contexts:
+- name: kubernetes-admin@tenant-00
+  context:
+    cluster: tenant-00
+    user: kubernetes-admin
+current-context: kubernetes-admin@tenant-00
+`
+
+// The Cluster API contract shape: Secret `<cluster>-kubeconfig`, key `value`.
+// CAPI emits multiple entries with an explicit current-context, which is exactly
+// the case resolve() refuses to guess about.
+const capiKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: capi-child
+  cluster:
+    server: https://192.168.1.196:6443
+    certificate-authority-data: Y2FkYXRh
+users:
+- name: capi-child-admin
+  user:
+    client-certificate-data: Y2VydGRhdGE=
+    client-key-data: a2V5ZGF0YQ==
+contexts:
+- name: capi-child-admin@capi-child
+  context:
+    cluster: capi-child
+    user: capi-child-admin
+current-context: capi-child-admin@capi-child
+`
+
+// CAPA's EKS path writes a SECOND `<cluster>-user-kubeconfig` carrying an exec
+// credential. It satisfies the CAPI glob and the `value` key, but cannot be
+// copied into an ArgoCD Secret at all.
+const execKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: managed
+  cluster:
+    server: https://example.eks.amazonaws.com
+    certificate-authority-data: Y2FkYXRh
+users:
+- name: managed
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws-iam-authenticator
+current-context: managed
+contexts:
+- name: managed
+  context:
+    cluster: managed
+    user: managed
+`
+
+func TestParseKubeconfigKamajiShape(t *testing.T) {
+	server, _, err := parseKubeconfig([]byte(kamajiKubeconfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "https://192.168.1.195:6443" {
+		t.Errorf("server = %q", server)
+	}
+}
+
+func TestParseKubeconfigCAPIShape(t *testing.T) {
+	server, config, err := parseKubeconfig([]byte(capiKubeconfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server != "https://192.168.1.196:6443" {
+		t.Errorf("server = %q", server)
+	}
+	if !strings.Contains(config, "certData") {
+		t.Errorf("expected client certs in the config blob, got %s", config)
+	}
+}
+
 func TestParseKubeconfigClientCerts(t *testing.T) {
 	server, config, err := parseKubeconfig([]byte(k3kKubeconfig))
 	if err != nil {
@@ -157,6 +249,33 @@ func TestPropagatedLabels(t *testing.T) {
 	}
 }
 
+// The source namespace is tenant-controlled and apply() copies these labels OVER
+// the ones it just computed, so anything not withheld here can be spoofed.
+//
+// `source-namespace` is the sharp one: it is the pointer garbage collection
+// follows to prove a source is gone. A namespace claiming
+// `<prefix>source-namespace: kube-system` would aim that proof at a namespace
+// that never disappears, and its registration could then never be collected.
+func TestPropagatedLabelsWithholdsReservedLabels(t *testing.T) {
+	const p = "example.com/"
+	got := propagatedLabels(map[string]string{
+		ManagedByLabel(p):        "reg",
+		ClusterLabel(p):          "c1",
+		SourceNamespaceLabel(p):  "kube-system",
+		ProviderLabel(p):         "not-really",
+		"example.com/legitimate": "yes",
+	}, p)
+
+	for _, reserved := range reservedSuffixes {
+		if _, ok := got[p+reserved]; ok {
+			t.Errorf("%q was propagated from the namespace and can therefore be spoofed", p+reserved)
+		}
+	}
+	if got["example.com/legitimate"] != "yes" {
+		t.Errorf("ordinary prefixed labels must still propagate, got %v", got)
+	}
+}
+
 // A custom --label-prefix must be honoured on both read and filter, otherwise the
 // tool only works for whoever picked the default.
 func TestPropagatedLabelsHonoursCustomPrefix(t *testing.T) {
@@ -173,8 +292,8 @@ func TestPropagatedLabelsHonoursCustomPrefix(t *testing.T) {
 }
 
 // vcluster writes both `vc-<name>` (the kubeconfig) and `vc-config-<name>` (its
-// own config) so a `vc-*` glob matches both, and the decoy sorts FIRST. Matching
-// on name alone picked the decoy and skipped the namespace entirely.
+// own config) so a `vc-*` glob matches both. Matching on name alone picked the
+// decoy and skipped the namespace entirely.
 func TestParseKubeconfigVclusterShape(t *testing.T) {
 	server, config, err := parseKubeconfig([]byte(vclusterKubeconfig))
 	if err != nil {

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -42,6 +42,10 @@ const (
 	// the source is genuinely gone rather than merely unseen this pass.
 	SuffixSourceNamespace = "source-namespace"
 
+	// SuffixProvider records which configured provider matched, so a fleet is
+	// introspectable and an ApplicationSet can select by provisioner.
+	SuffixProvider = "provider"
+
 	// argoSecretTypeLabel is what makes ArgoCD treat a Secret as a cluster. It is
 	// a label key, not a credential; gosec G101 matches on the identifier holding
 	// "Secret" next to a string literal.
@@ -58,6 +62,158 @@ func ClusterLabel(prefix string) string { return prefix + SuffixCluster }
 // SourceNamespaceLabel is the source-namespace label key for a given prefix.
 func SourceNamespaceLabel(prefix string) string { return prefix + SuffixSourceNamespace }
 
+// ProviderLabel is the matched-provider label key for a given prefix.
+func ProviderLabel(prefix string) string { return prefix + SuffixProvider }
+
+// reservedSuffixes are the labels this tool derives itself. They are written on
+// every cluster Secret from what we observed, never copied from the source
+// namespace -- otherwise a namespace could set them and lie about its own
+// registration. `source-namespace` is the dangerous one: it is the pointer
+// garbage collection follows to prove a source is gone, so a namespace labelling
+// itself `<prefix>source-namespace: kube-system` would aim that proof at a
+// namespace that never disappears and make its registration immortal.
+var reservedSuffixes = []string{
+	SuffixManagedBy,
+	SuffixCluster,
+	SuffixSourceNamespace,
+	SuffixProvider,
+}
+
+// Provider is one provisioner's kubeconfig Secret shape.
+//
+// The pattern and the keys travel together as a unit, and that pairing is
+// load-bearing rather than tidy: it is what tells a real kubeconfig apart from a
+// decoy sitting under the same prefix. vcluster's `vc-*` matches both `vc-<name>`
+// (key `config`) and `vc-config-<name>` (key `config.yaml`). Whether the decoy
+// sorts first depends on the names -- `vc-config-x` precedes `vc-x`, but
+// `vc-config-abc` follows `vc-abc` -- so the key is the only reliable
+// discriminator. Two independent lists of patterns and keys would lose that.
+type Provider struct {
+	// Name identifies the provider in logs and on the cluster Secret's provider
+	// label. It is not matched against anything.
+	Name string
+
+	// SecretNamePattern is a glob matched against Secret names within a
+	// discovered namespace, e.g. "k3k-*-kubeconfig".
+	//
+	// Matching by NAME rather than by label is not a stylistic choice: the
+	// provisioner creates that Secret itself (k3k gives it an ownerReference to
+	// the Cluster), so it carries none of our labels and there is nowhere to add
+	// them. The namespace is the nearest object we own, which is why intent lives
+	// there instead.
+	SecretNamePattern string
+
+	// SecretKeys are the keys that may hold the kubeconfig, tried in order. A
+	// list rather than a single key because one provisioner can legitimately use
+	// either: Kamaji writes `admin.conf`, or `admin.svc` when its control plane
+	// advertises a service address.
+	SecretKeys []string
+}
+
+// presets are the provisioner shapes shipped with the tool, so that configuring
+// one is `providers: [k3k, capi]` rather than a glob a user has to get right.
+//
+// Only k3k, vcluster and kamaji have been run against the real thing; see the
+// provisioner table in README.md, which distinguishes tested from assumed and
+// should be kept honest.
+//
+// Every entry carries `#nosec G101`. gosec matches that rule on identifiers like
+// `Secret*` sitting next to a string literal, which describes this map exactly --
+// but `SecretNamePattern` is a glob matched against Secret NAMES and `SecretKeys`
+// are map keys inside a Secret. Neither is a credential, and nothing here is ever
+// compared against one. The same false positive is already annotated on
+// argoSecretTypeLabel above.
+var presets = map[string]Provider{
+	"k3k": { // #nosec G101 -- a Secret name glob and a data key, not a credential
+		Name:              "k3k",
+		SecretNamePattern: "k3k-*-kubeconfig",
+		SecretKeys:        []string{"kubeconfig.yaml"},
+	},
+	"vcluster": { // #nosec G101 -- see above
+		Name:              "vcluster",
+		SecretNamePattern: "vc-*",
+		SecretKeys:        []string{"config"},
+	},
+	// Kamaji's standalone shape. Note that driving Kamaji through its Cluster API
+	// control-plane provider ALSO produces a second, CAPI-shaped Secret for the
+	// same physical cluster -- see the note on candidate ordering in discover.
+	"kamaji": { // #nosec G101 -- see above
+		Name:              "kamaji",
+		SecretNamePattern: "*-admin-kubeconfig",
+		SecretKeys:        []string{"admin.conf", "admin.svc"},
+	},
+	// The Cluster API contract, which is mandatory for control-plane providers
+	// rather than merely conventional: the Secret must be `<cluster>-kubeconfig`
+	// in the Cluster's namespace with the kubeconfig under `value`. That makes
+	// this one entry cover every CAPI cluster whatever the infrastructure
+	// provider, including standalone k0smotron, which adopts the same shape.
+	//
+	// This is deliberately the loosest pattern shipped: `*-kubeconfig` also
+	// matches k3k's Secret and anything else in a managed namespace ending that
+	// way. Correctness comes from the key, not the name.
+	"capi": { // #nosec G101 -- see above
+		Name:              "capi",
+		SecretNamePattern: "*-kubeconfig",
+		SecretKeys:        []string{"value"},
+	},
+}
+
+// Preset returns a built-in provider by name.
+func Preset(name string) (Provider, bool) {
+	p, ok := presets[name]
+	return p, ok
+}
+
+// PresetNames lists the built-in providers, sorted, for help text and errors.
+func PresetNames() []string {
+	out := make([]string, 0, len(presets))
+	for name := range presets {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ParseProvider reads one provider spec: either a preset name ("k3k"), or a
+// custom shape as "name=pattern=key[,key...]".
+func ParseProvider(spec string) (Provider, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return Provider{}, fmt.Errorf("empty provider spec")
+	}
+
+	if !strings.Contains(spec, "=") {
+		p, ok := Preset(spec)
+		if !ok {
+			return Provider{}, fmt.Errorf(
+				"unknown provider %q: expected one of %s, or a custom spec \"name=pattern=key[,key...]\"",
+				spec, strings.Join(PresetNames(), ", "))
+		}
+		return p, nil
+	}
+
+	parts := strings.Split(spec, "=")
+	if len(parts) != 3 {
+		return Provider{}, fmt.Errorf(
+			"malformed provider spec %q: expected \"name=pattern=key[,key...]\"", spec)
+	}
+
+	var keys []string
+	for _, k := range strings.Split(parts[2], ",") {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+
+	// Validate() re-checks all of this; returning a well-formed value here keeps
+	// the error messages about spec syntax rather than about configuration.
+	return Provider{
+		Name:              strings.TrimSpace(parts[0]),
+		SecretNamePattern: strings.TrimSpace(parts[1]),
+		SecretKeys:        keys,
+	}, nil
+}
+
 // Config controls a single reconcile pass.
 type Config struct {
 	// TargetNamespace is where ArgoCD reads cluster Secrets from. ArgoCD only
@@ -68,18 +224,10 @@ type Config struct {
 	// discovered; cluster Secrets labelled with it are eligible for GC.
 	ManagedByValue string
 
-	// SecretNamePattern matches the kubeconfig Secret within a discovered
-	// namespace, e.g. "k3k-*-kubeconfig".
-	//
-	// Matching by NAME rather than by label is not a stylistic choice: k3k creates
-	// that Secret itself (with an ownerReference to the Cluster), so it carries
-	// none of our labels and there is nowhere to add them. The namespace is the
-	// nearest object we own, which is why intent lives there instead.
-	SecretNamePattern string
-
-	// SecretKey is the kubeconfig key inside that Secret. k3k uses
-	// "kubeconfig.yaml"; vcluster uses "config"; CAPI uses "value".
-	SecretKey string
+	// Providers are the provisioner shapes to look for, in precedence order.
+	// Order matters because the patterns legitimately overlap: the CAPI preset's
+	// `*-kubeconfig` also matches k3k's Secret.
+	Providers []Provider
 
 	// LabelPrefix namespaces the labels read from the source namespace and copied
 	// onto the ArgoCD cluster Secret. Defaults to DefaultLabelPrefix.
@@ -125,16 +273,48 @@ func (c Config) Validate() error {
 	if c.ManagedByValue == "" {
 		return fmt.Errorf("--managed-by must not be empty")
 	}
-	if c.SecretKey == "" {
-		return fmt.Errorf("--secret-key must not be empty")
+	if len(c.Providers) == 0 {
+		return fmt.Errorf("at least one provider must be configured")
 	}
-	if c.SecretNamePattern == "" {
-		return fmt.Errorf("--secret-name-pattern must not be empty")
-	}
-	// A malformed glob is a permanent fault. It used to surface once per
-	// namespace per pass, disguised as "no kubeconfig secret yet".
-	if _, err := path.Match(c.SecretNamePattern, "probe"); err != nil {
-		return fmt.Errorf("--secret-name-pattern %q is not a valid glob: %w", c.SecretNamePattern, err)
+	seen := map[string]bool{}
+	for i, p := range c.Providers {
+		if p.Name == "" {
+			return fmt.Errorf("provider %d has no name", i)
+		}
+		// The name is written verbatim as a label value on every cluster Secret
+		// this provider matches, so an invalid one is not a cosmetic problem: it
+		// is accepted at startup and then rejected by the apiserver on EVERY
+		// apply, forever, per cluster. Same reasoning as the DNS-1123 check on
+		// cluster names below. The fake clientset used in tests does not validate
+		// labels, so nothing else would catch it.
+		if errs := validation.IsValidLabelValue(p.Name); len(errs) > 0 {
+			return fmt.Errorf("provider %q: name is not a valid label value: %s",
+				p.Name, strings.Join(errs, "; "))
+		}
+		// Two providers sharing a name would make the provider label ambiguous
+		// and the logs unreadable.
+		if seen[p.Name] {
+			return fmt.Errorf("duplicate provider name %q", p.Name)
+		}
+		seen[p.Name] = true
+
+		if p.SecretNamePattern == "" {
+			return fmt.Errorf("provider %q: secret name pattern must not be empty", p.Name)
+		}
+		if len(p.SecretKeys) == 0 {
+			return fmt.Errorf("provider %q: at least one secret key must be set", p.Name)
+		}
+		for _, k := range p.SecretKeys {
+			if k == "" {
+				return fmt.Errorf("provider %q: secret key must not be empty", p.Name)
+			}
+		}
+		// A malformed glob is a permanent fault. It used to surface once per
+		// namespace per pass, disguised as "no kubeconfig secret yet".
+		if _, err := path.Match(p.SecretNamePattern, "probe"); err != nil {
+			return fmt.Errorf("provider %q: secret name pattern %q is not a valid glob: %w",
+				p.Name, p.SecretNamePattern, err)
+		}
 	}
 	if p := c.LabelPrefix; p != "" && !strings.HasSuffix(p, "/") {
 		// Without the slash the keys become nonsense like "example.commanaged-by"
@@ -153,6 +333,7 @@ func (c Config) Validate() error {
 func (r *Registrar) managedByLabel() string       { return ManagedByLabel(r.cfg.LabelPrefix) }
 func (r *Registrar) clusterLabel() string         { return ClusterLabel(r.cfg.LabelPrefix) }
 func (r *Registrar) sourceNamespaceLabel() string { return SourceNamespaceLabel(r.cfg.LabelPrefix) }
+func (r *Registrar) providerLabel() string        { return ProviderLabel(r.cfg.LabelPrefix) }
 
 // clientTimeout bounds every API call. Without it rest.Config.Timeout is 0, so a
 // hung request inside Reconcile blocks forever: the ticker never fires again and
@@ -185,7 +366,7 @@ func restConfig() (*rest.Config, error) {
 // rotate the client certificate, and a stale Secret breaks every Application
 // targeting that cluster with an authentication error rather than a visible one.
 func (r *Registrar) Reconcile(ctx context.Context) error {
-	desired, complete, err := r.discover(ctx)
+	desired, unresolved, err := r.discover(ctx)
 	if err != nil {
 		return err
 	}
@@ -200,14 +381,16 @@ func (r *Registrar) Reconcile(ctx context.Context) error {
 		}
 	}
 
-	// Garbage collection runs ONLY on a complete picture. `desired` is built by
-	// skipping namespaces that could not be evaluated, so a transient API error
-	// makes a live cluster look deleted. Without this guard one 500 from the
-	// apiserver would deregister the entire fleet, break every Application
-	// pointing at it, and re-create the lot on the next pass.
-	if !complete {
-		r.log.Warn("skipping garbage collection: could not evaluate every managed namespace this pass")
-	} else if err := r.collect(ctx, desired); err != nil {
+	// `desired` is built by skipping namespaces that could not be evaluated, so a
+	// transient API error makes a live cluster look deleted. Rather than skipping
+	// GC entirely -- which let one stuck namespace keep every dead registration
+	// alive -- the unevaluable namespaces are passed down and excluded
+	// individually. Every other cluster is still collected normally.
+	if len(unresolved) > 0 {
+		r.log.Warn("some managed namespaces could not be evaluated; their registrations are exempt from garbage collection this pass",
+			slog.Int("count", len(unresolved)))
+	}
+	if err := r.collect(ctx, desired, unresolved); err != nil {
 		errs = append(errs, fmt.Sprintf("gc: %v", err))
 	}
 
@@ -223,6 +406,7 @@ type child struct {
 	namespace string
 	server    string
 	config    string
+	provider  string
 	labels    map[string]string
 }
 
@@ -233,20 +417,26 @@ type apiFailure struct{ err error }
 func (e *apiFailure) Error() string { return e.err.Error() }
 func (e *apiFailure) Unwrap() error { return e.err }
 
-// discover returns the clusters that should be registered, and whether every
-// managed namespace was successfully evaluated.
+// discover returns the clusters that should be registered, and the set of
+// managed namespaces that could not be evaluated this pass.
 //
-// The bool is load-bearing: callers must not treat "absent from the result" as
-// "deleted" unless it is true. A namespace that could not be read is omitted
-// from the result but clears the flag.
-func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
+// That set is load-bearing: callers must not treat "absent from the result" as
+// "deleted" for a namespace listed in it. A namespace that could not be read is
+// omitted from the result and recorded there instead.
+//
+// It is a set rather than the single bool this used to be, because one
+// unevaluable namespace used to disable garbage collection for the entire fleet.
+// A cluster stuck without a kubeconfig -- which every k3k child is for its first
+// ninety seconds, and a permanently broken one is forever -- would silently keep
+// every other cluster's dead registration alive.
+func (r *Registrar) discover(ctx context.Context) ([]child, map[string]bool, error) {
 	selector := fmt.Sprintf("%s=%s", r.managedByLabel(), r.cfg.ManagedByValue)
 	namespaces, err := r.client.CoreV1().Namespaces().List(ctx, metaV1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		return nil, false, fmt.Errorf("list namespaces (%s): %w", selector, err)
+		return nil, nil, fmt.Errorf("list namespaces (%s): %w", selector, err)
 	}
 
-	complete := true
+	unresolved := map[string]bool{}
 	var out []child
 	seen := map[string]string{}
 	for i := range namespaces.Items {
@@ -263,7 +453,7 @@ func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
 		if name == "" {
 			r.log.Warn("namespace is managed but has no cluster label; skipping",
 				slog.String("namespace", ns.Name), slog.String("label", r.clusterLabel()))
-			complete = false
+			unresolved[ns.Name] = true
 			continue
 		}
 
@@ -275,7 +465,7 @@ func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
 			r.log.Error("cluster name does not yield a valid Secret name; skipping",
 				slog.String("namespace", ns.Name), slog.String("cluster", name),
 				slog.String("reason", strings.Join(errs, "; ")))
-			complete = false
+			unresolved[ns.Name] = true
 			continue
 		}
 
@@ -285,13 +475,16 @@ func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
 			r.log.Error("duplicate cluster name across namespaces; skipping both",
 				slog.String("cluster", name), slog.String("namespace", ns.Name),
 				slog.String("conflictsWith", other))
-			complete = false
+			// Both namespaces are now unresolved: the winner was withdrawn from
+			// `out` as well, so neither may be treated as deleted.
+			unresolved[ns.Name] = true
+			unresolved[other] = true
 			out = slices.DeleteFunc(out, func(c child) bool { return c.cluster == name })
 			continue
 		}
 		seen[name] = ns.Name
 
-		secret, err := r.findKubeconfigSecret(ctx, ns.Name)
+		candidates, err := r.findKubeconfigCandidates(ctx, ns.Name)
 		if err != nil {
 			var apiErr *apiFailure
 			if errors.As(err, &apiErr) {
@@ -300,27 +493,48 @@ func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
 				// used to look reassuring in the logs.
 				r.log.Error("could not read secrets in managed namespace",
 					slog.String("namespace", ns.Name), slog.String("cluster", name), slog.Any("error", err))
-				complete = false
+				unresolved[ns.Name] = true
 				continue
 			}
 			// Entirely normal between the Cluster CR being created and its server
-			// becoming ready -- k3k only writes the kubeconfig once the API is up.
+			// becoming ready -- k3k only writes the kubeconfig once the API is up,
+			// and reports ProvisioningFailed for roughly the first ninety seconds
+			// while it does.
 			r.log.Info("no kubeconfig secret yet; will retry",
 				slog.String("namespace", ns.Name), slog.String("cluster", name), slog.Any("reason", err))
-			complete = false
+			unresolved[ns.Name] = true
 			continue
 		}
 
-		// findKubeconfigSecret already guarantees the key is present.
-		raw := secret.Data[r.cfg.SecretKey]
-
-		server, config, err := parseKubeconfig(raw)
-		if err != nil {
+		// Try candidates in order. A shape match is not a usable kubeconfig: it
+		// may be half-written, or carry an exec credential that cannot be copied
+		// into an ArgoCD Secret, and in both cases the next candidate may be fine.
+		var (
+			server, config string
+			provider       string
+			parseErrs      []string
+		)
+		for _, c := range candidates {
+			s, cfg, perr := parseKubeconfig(c.secret.Data[c.key])
+			if perr != nil {
+				parseErrs = append(parseErrs, fmt.Sprintf("%s[%s]: %v", c.secret.Name, c.key, perr))
+				continue
+			}
+			server, config, provider = s, cfg, c.provider
+			if len(parseErrs) > 0 {
+				r.log.Debug("skipped unusable kubeconfig candidates before this one",
+					slog.String("namespace", ns.Name), slog.String("using", c.secret.Name),
+					slog.Any("skipped", parseErrs))
+			}
+			break
+		}
+		if provider == "" {
 			// Could be a half-written kubeconfig, so this must not look like a
 			// deletion either.
-			r.log.Warn("unparseable kubeconfig; skipping",
-				slog.String("secret", secret.Name), slog.Any("error", err))
-			complete = false
+			r.log.Warn("no usable kubeconfig; skipping",
+				slog.String("namespace", ns.Name), slog.String("cluster", name),
+				slog.Any("errors", parseErrs))
+			unresolved[ns.Name] = true
 			continue
 		}
 
@@ -329,24 +543,43 @@ func (r *Registrar) discover(ctx context.Context) ([]child, bool, error) {
 			namespace: ns.Name,
 			server:    server,
 			config:    config,
+			provider:  provider,
 			labels:    propagatedLabels(ns.Labels, r.cfg.LabelPrefix),
 		})
 	}
 
 	// Stable ordering keeps logs diffable between passes.
 	sort.Slice(out, func(i, j int) bool { return out[i].cluster < out[j].cluster })
-	return out, complete, nil
+	return out, unresolved, nil
 }
 
-// findKubeconfigSecret returns the first Secret in ns whose name matches the
-// configured glob AND which actually carries the configured key.
+// candidate is a Secret that matched some provider, together with the provider
+// that matched and the key holding the kubeconfig.
+type candidate struct {
+	secret   *coreV1.Secret
+	provider string
+	key      string
+}
+
+// findKubeconfigCandidates returns every Secret in ns that matches a configured
+// provider's glob AND carries one of that provider's keys, in the order they
+// should be tried: providers in configured precedence order, then Secret name.
 //
 // Both conditions matter. A name-only match picks the wrong object whenever a
 // provisioner writes more than one Secret under the same prefix: vcluster's
-// `vc-*` matches both `vc-<name>` (the kubeconfig) and `vc-config-<name>` (the
-// vcluster config), and the latter sorts first. Requiring the key means the
-// alphabetically-earlier decoy is skipped instead of poisoning the namespace.
-func (r *Registrar) findKubeconfigSecret(ctx context.Context, ns string) (*coreV1.Secret, error) {
+// `vc-*` matches both `vc-<name>` (the kubeconfig, key `config`) and
+// `vc-config-<name>` (the vcluster config, key `config.yaml`). Requiring the key
+// means the decoy is skipped rather than poisoning the namespace, whichever way
+// the two happen to sort.
+//
+// A LIST rather than a single answer, because matching the shape is not the same
+// as being usable. Cluster API's contract is satisfied by managed-cloud
+// providers too, and CAPA's EKS path writes a second `<cluster>-user-kubeconfig`
+// -- same glob, same `value` key -- holding an `exec` credential that cannot be
+// copied into an ArgoCD Secret at all. Returning candidates lets the caller fall
+// through to the next one on a parse failure, instead of relying on `k` sorting
+// before `u`.
+func (r *Registrar) findKubeconfigCandidates(ctx context.Context, ns string) ([]candidate, error) {
 	secrets, err := r.client.CoreV1().Secrets(ns).List(ctx, metaV1.ListOptions{})
 	if err != nil {
 		return nil, &apiFailure{fmt.Errorf("list secrets: %w", err)}
@@ -362,41 +595,82 @@ func (r *Registrar) findKubeconfigSecret(ctx context.Context, ns string) (*coreV
 		return secrets.Items[idx[a]].Name < secrets.Items[idx[b]].Name
 	})
 
+	var out []candidate
 	var namedButKeyless []string
-	for _, i := range idx {
-		s := &secrets.Items[i]
-		ok, err := path.Match(r.cfg.SecretNamePattern, s.Name)
-		if err != nil {
-			// A permanent configuration fault, not a transient one. New()
-			// validates the pattern up front so this should be unreachable.
-			return nil, &apiFailure{fmt.Errorf("bad secret name pattern %q: %w", r.cfg.SecretNamePattern, err)}
+	claimed := map[string]bool{}
+
+	for _, p := range r.cfg.Providers {
+		for _, i := range idx {
+			s := &secrets.Items[i]
+			ok, err := path.Match(p.SecretNamePattern, s.Name)
+			if err != nil {
+				// A permanent configuration fault, not a transient one. Validate()
+				// checks every pattern up front so this should be unreachable.
+				return nil, &apiFailure{fmt.Errorf("provider %q: bad secret name pattern %q: %w",
+					p.Name, p.SecretNamePattern, err)}
+			}
+			if !ok {
+				continue
+			}
+			// An earlier provider already claimed this Secret. Skip it rather than
+			// offering it twice: the patterns overlap by design (`*-kubeconfig`
+			// matches k3k's Secret too) and a duplicate entry would only ever
+			// produce the same registration.
+			if claimed[s.Name] {
+				continue
+			}
+
+			key := ""
+			for _, k := range p.SecretKeys {
+				if _, has := s.Data[k]; has {
+					key = k
+					break
+				}
+			}
+			if key == "" {
+				namedButKeyless = append(namedButKeyless,
+					fmt.Sprintf("%s (provider %s)", s.Name, p.Name))
+				continue
+			}
+
+			claimed[s.Name] = true
+			out = append(out, candidate{secret: s, provider: p.Name, key: key})
 		}
-		if !ok {
-			continue
-		}
-		if _, hasKey := s.Data[r.cfg.SecretKey]; !hasKey {
-			namedButKeyless = append(namedButKeyless, s.Name)
-			continue
-		}
-		return s, nil
 	}
 
-	if len(namedButKeyless) > 0 {
-		return nil, fmt.Errorf("secret(s) %v match %q but none carry key %q",
-			namedButKeyless, r.cfg.SecretNamePattern, r.cfg.SecretKey)
+	if len(out) > 0 {
+		return out, nil
 	}
-	return nil, fmt.Errorf("no secret matching %q", r.cfg.SecretNamePattern)
+	// Only worth reporting when nothing matched at all. With overlapping patterns
+	// a keyless near-miss is routine -- every k3k Secret is one, for the CAPI
+	// provider -- and reporting it on a successful pass would turn a real signal
+	// into noise.
+	if len(namedButKeyless) > 0 {
+		return nil, fmt.Errorf("secret(s) %v matched a provider pattern but carried none of its keys",
+			namedButKeyless)
+	}
+	return nil, fmt.Errorf("no secret matching any configured provider")
 }
 
 // propagatedLabels copies the prefixed labels the ApplicationSet selects on,
-// minus the ones that describe the source rather than the cluster.
+// minus the ones this tool derives for itself.
+//
+// The exclusions are a trust boundary, not tidiness. Everything here comes off
+// the source namespace, which a tenant may control, and apply() copies these
+// over the labels it just computed -- so anything not excluded can be spoofed.
+// See reservedSuffixes for what that would cost.
 func propagatedLabels(in map[string]string, prefix string) map[string]string {
+	reserved := map[string]bool{}
+	for _, suffix := range reservedSuffixes {
+		reserved[prefix+suffix] = true
+	}
+
 	out := map[string]string{}
 	for k, v := range in {
 		if !strings.HasPrefix(k, prefix) {
 			continue
 		}
-		if k == ManagedByLabel(prefix) || k == ClusterLabel(prefix) {
+		if reserved[k] {
 			continue
 		}
 		out[k] = v
@@ -408,11 +682,15 @@ func propagatedLabels(in map[string]string, prefix string) map[string]string {
 func secretName(cluster string) string { return "cluster-" + cluster }
 
 func (r *Registrar) apply(ctx context.Context, c child) error {
+	// Order matters: the propagated labels are copied LAST, so anything they can
+	// reach wins over what was computed here. propagatedLabels already withholds
+	// every reserved suffix for exactly that reason -- see reservedSuffixes.
 	labels := map[string]string{
 		argoSecretTypeLabel:      argoSecretTypeValue,
 		r.managedByLabel():       r.cfg.ManagedByValue,
 		r.clusterLabel():         c.cluster,
 		r.sourceNamespaceLabel(): c.namespace,
+		r.providerLabel():        c.provider,
 	}
 	maps.Copy(labels, c.labels)
 
@@ -527,9 +805,14 @@ func changed(existing, want *coreV1.Secret, labelPrefix string) bool {
 // definite NotFound before anything is removed. Absence alone is not evidence:
 // a namespace can drop out of `desired` because an API call failed, because a
 // kubeconfig was half-written, or because a label was edited, and treating any
-// of those as "deleted" would deregister live clusters. Reconcile also refuses
-// to call this at all on an incomplete pass; this is the second line of defence.
-func (r *Registrar) collect(ctx context.Context, desired []child) error {
+// of those as "deleted" would deregister live clusters.
+//
+// `unresolved` names the namespaces discover could not evaluate this pass. Their
+// registrations are skipped outright, before the existence check, so a namespace
+// that exists but could not be read is never a deletion candidate at all. The
+// namespace Get below is still the proof that matters -- this is the first line
+// of defence, not a replacement for it.
+func (r *Registrar) collect(ctx context.Context, desired []child, unresolved map[string]bool) error {
 	live := map[string]bool{}
 	for _, d := range desired {
 		live[secretName(d.cluster)] = true
@@ -558,6 +841,12 @@ func (r *Registrar) collect(ctx context.Context, desired []child) error {
 			// rather than guessing.
 			r.log.Warn("owned cluster secret has no source-namespace label; not deleting",
 				slog.String("secret", s.Name), slog.String("label", r.sourceNamespaceLabel()))
+			continue
+		}
+
+		if unresolved[srcNS] {
+			r.log.Debug("source namespace could not be evaluated this pass; not deleting",
+				slog.String("secret", s.Name), slog.String("namespace", srcNS))
 			continue
 		}
 

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	coreV1 "k8s.io/api/core/v1"
@@ -23,13 +24,27 @@ const (
 )
 
 func testConfig() Config {
+	k3k, _ := Preset("k3k")
 	return Config{
-		TargetNamespace:   "argocd",
-		ManagedByValue:    testManagedBy,
-		SecretNamePattern: "k3k-*-kubeconfig",
-		SecretKey:         "kubeconfig.yaml",
-		LabelPrefix:       testPrefix,
+		TargetNamespace: "argocd",
+		ManagedByValue:  testManagedBy,
+		Providers:       []Provider{k3k},
+		LabelPrefix:     testPrefix,
 	}
+}
+
+// mustPresets is a shorthand for building a provider list in tests.
+func mustPresets(t *testing.T, names ...string) []Provider {
+	t.Helper()
+	out := make([]Provider, 0, len(names))
+	for _, n := range names {
+		p, ok := Preset(n)
+		if !ok {
+			t.Fatalf("unknown preset %q", n)
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func newTestRegistrar(objs ...runtime.Object) (*Registrar, *fake.Clientset) {
@@ -121,7 +136,7 @@ func TestCollectRequiresProofTheNamespaceIsGone(t *testing.T) {
 	}}
 	r, c := newTestRegistrar(unlabelled, registeredSecret("a", "k3k-a"))
 
-	if err := r.collect(context.Background(), nil); err != nil {
+	if err := r.collect(context.Background(), nil, nil); err != nil {
 		t.Fatalf("collect: %v", err)
 	}
 	if !secretExists(t, c, "cluster-a") {
@@ -131,7 +146,7 @@ func TestCollectRequiresProofTheNamespaceIsGone(t *testing.T) {
 
 func TestCollectDeletesWhenNamespaceIsActuallyGone(t *testing.T) {
 	r, c := newTestRegistrar(registeredSecret("gone", "k3k-gone"))
-	if err := r.collect(context.Background(), nil); err != nil {
+	if err := r.collect(context.Background(), nil, nil); err != nil {
 		t.Fatalf("collect: %v", err)
 	}
 	if secretExists(t, c, "cluster-gone") {
@@ -148,7 +163,7 @@ func TestCollectNeverTouchesUnlabelledSecrets(t *testing.T) {
 		Labels:    map[string]string{argoSecretTypeLabel: argoSecretTypeValue},
 	}}
 	r, c := newTestRegistrar(hand)
-	if err := r.collect(context.Background(), nil); err != nil {
+	if err := r.collect(context.Background(), nil, nil); err != nil {
 		t.Fatalf("collect: %v", err)
 	}
 	if !secretExists(t, c, "cluster-handmade") {
@@ -166,7 +181,7 @@ func TestCollectContinuesPastDeleteErrors(t *testing.T) {
 		return false, nil, nil
 	})
 
-	if err := r.collect(context.Background(), nil); err == nil {
+	if err := r.collect(context.Background(), nil, nil); err == nil {
 		t.Error("expected the forbidden delete to be reported")
 	}
 	if secretExists(t, c, "cluster-b") {
@@ -225,15 +240,176 @@ func TestFindKubeconfigSecretSkipsDecoy(t *testing.T) {
 		Data:       map[string][]byte{"config": []byte(vclusterKubeconfig)},
 	}
 	r, _ := newTestRegistrar(decoy, wanted)
-	r.cfg.SecretNamePattern = "vc-*"
-	r.cfg.SecretKey = "config"
+	r.cfg.Providers = mustPresets(t, "vcluster")
 
-	got, err := r.findKubeconfigSecret(context.Background(), "ns")
+	got, err := r.findKubeconfigCandidates(context.Background(), "ns")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.Name != "vc-x" {
-		t.Errorf("picked %q, want vc-x (the decoy sorts first)", got.Name)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one candidate, got %d: %+v", len(got), got)
+	}
+	if got[0].secret.Name != "vc-x" {
+		t.Errorf("picked %q, want vc-x (these names put the decoy first)", got[0].secret.Name)
+	}
+}
+
+func secretWith(ns, name, key, body string) *coreV1.Secret {
+	return &coreV1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       map[string][]byte{key: []byte(body)},
+	}
+}
+
+// Two provisioners under ONE registrar is the whole point of 0.3.0: before it,
+// a second shape needed a second Deployment, and two Deployments sharing a
+// managed-by value garbage collect each other's Secrets.
+func TestMultipleProvidersRegisterSideBySide(t *testing.T) {
+	r, c := newTestRegistrar(
+		managedNS("k3k-a", "a"), kubeconfigSecret("k3k-a", "k3k-a-kubeconfig"),
+		managedNS("tenant-b", "b"), secretWith("tenant-b", "b-admin-kubeconfig", "admin.conf", kamajiKubeconfig),
+	)
+	r.cfg.Providers = mustPresets(t, "k3k", "kamaji")
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	for cluster, wantProvider := range map[string]string{"a": "k3k", "b": "kamaji"} {
+		got, err := c.CoreV1().Secrets("argocd").Get(context.Background(), secretName(cluster), metaV1.GetOptions{})
+		if err != nil {
+			t.Fatalf("cluster-%s was not registered: %v", cluster, err)
+		}
+		if got.Labels[ProviderLabel(testPrefix)] != wantProvider {
+			t.Errorf("cluster-%s provider label = %q, want %q",
+				cluster, got.Labels[ProviderLabel(testPrefix)], wantProvider)
+		}
+	}
+}
+
+// Deleting one child must collect exactly that registration. Cross-provider GC
+// is the way this change could destroy data, so it is asserted directly.
+func TestGarbageCollectionIsPerClusterAcrossProviders(t *testing.T) {
+	r, c := newTestRegistrar(
+		managedNS("k3k-a", "a"), kubeconfigSecret("k3k-a", "k3k-a-kubeconfig"), registeredSecret("a", "k3k-a"),
+		// b's namespace is gone; only its registration remains.
+		registeredSecret("b", "tenant-b"),
+	)
+	r.cfg.Providers = mustPresets(t, "k3k", "kamaji")
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-a") {
+		t.Error("cluster-a was collected although its namespace is still present")
+	}
+	if secretExists(t, c, "cluster-b") {
+		t.Error("cluster-b should have been collected once its namespace was gone")
+	}
+}
+
+// Driving Kamaji through its Cluster API control-plane provider produces TWO
+// Secrets for one physical cluster: Kamaji's own `<tcp>-admin-kubeconfig`, and a
+// CAPI-shaped `<cluster>-kubeconfig` copied from it. With both presets enabled
+// they both match, and registering each would put one cluster into ArgoCD twice.
+func TestKamajiViaCAPIRegistersOnce(t *testing.T) {
+	r, c := newTestRegistrar(
+		managedNS("tenant-b", "b"),
+		secretWith("tenant-b", "b-admin-kubeconfig", "admin.conf", kamajiKubeconfig),
+		secretWith("tenant-b", "b-kubeconfig", "value", capiKubeconfig),
+	)
+	r.cfg.Providers = mustPresets(t, "kamaji", "capi")
+
+	children, _, err := r.discover(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("one physical cluster produced %d registrations: %+v", len(children), children)
+	}
+	if children[0].provider != "kamaji" {
+		t.Errorf("provider = %q, want kamaji (declared first)", children[0].provider)
+	}
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	list, err := c.CoreV1().Secrets("argocd").List(context.Background(), metaV1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Errorf("expected exactly one cluster Secret, got %d", len(list.Items))
+	}
+}
+
+// A Secret can match the shape and still be unusable. CAPA's EKS path writes
+// `<cluster>-user-kubeconfig` with an exec credential, which satisfies the CAPI
+// glob and the `value` key but cannot be copied into an ArgoCD Secret.
+//
+// In the real EKS layout `c-kubeconfig` happens to sort before
+// `c-user-kubeconfig`, so picking the first match would work by luck. The unusable
+// Secret here is named to sort FIRST, so this passes only if a failed parse
+// genuinely falls through to the next candidate.
+func TestPrefersUsableCandidateOverExecCredential(t *testing.T) {
+	r, _ := newTestRegistrar(
+		managedNS("capi-c", "c"),
+		secretWith("capi-c", "aaa-kubeconfig", "value", execKubeconfig),
+		secretWith("capi-c", "c-kubeconfig", "value", capiKubeconfig),
+	)
+	r.cfg.Providers = mustPresets(t, "capi")
+
+	children, _, err := r.discover(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected one registration, got %d: %+v", len(children), children)
+	}
+	if children[0].server != "https://192.168.1.196:6443" {
+		t.Errorf("registered the exec-credential kubeconfig: server = %q", children[0].server)
+	}
+}
+
+// A k3k Cluster reports ProvisioningFailed with `invalid character '<'` for
+// roughly its first ninety seconds, so a Secret can exist holding content that
+// does not parse. That window must never look like a deletion.
+func TestUnparseableKubeconfigDoesNotDeregister(t *testing.T) {
+	r, c := newTestRegistrar(
+		managedNS("k3k-a", "a"),
+		secretWith("k3k-a", "k3k-a-kubeconfig", "kubeconfig.yaml", "<html>not a kubeconfig</html>"),
+		registeredSecret("a", "k3k-a"),
+	)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Logf("reconcile reported: %v", err)
+	}
+	if !secretExists(t, c, "cluster-a") {
+		t.Error("a half-written kubeconfig deregistered a live cluster")
+	}
+}
+
+// One namespace stuck without a usable kubeconfig used to disable garbage
+// collection for the entire fleet, so every other cluster's dead registration
+// stayed in ArgoCD indefinitely.
+func TestUnresolvedNamespaceDoesNotBlockCollectionOfOthers(t *testing.T) {
+	r, c := newTestRegistrar(
+		// Permanently stuck: matches the glob, never parses.
+		managedNS("k3k-stuck", "stuck"),
+		secretWith("k3k-stuck", "k3k-stuck-kubeconfig", "kubeconfig.yaml", "<html>"),
+		registeredSecret("stuck", "k3k-stuck"),
+		// Genuinely gone, and unrelated to the stuck one.
+		registeredSecret("gone", "k3k-gone"),
+	)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Logf("reconcile reported: %v", err)
+	}
+	if !secretExists(t, c, "cluster-stuck") {
+		t.Error("the stuck cluster must be exempt from GC, not collected")
+	}
+	if secretExists(t, c, "cluster-gone") {
+		t.Error("an unrelated stuck namespace blocked collection of a genuinely deleted cluster")
 	}
 }
 
@@ -241,9 +417,26 @@ func TestConfigValidate(t *testing.T) {
 	for name, mutate := range map[string]func(*Config){
 		"empty target namespace": func(c *Config) { c.TargetNamespace = "" },
 		"empty managed-by":       func(c *Config) { c.ManagedByValue = "" },
-		"empty secret key":       func(c *Config) { c.SecretKey = "" },
-		"bad glob":               func(c *Config) { c.SecretNamePattern = "k3k-[" },
-		"prefix without slash":   func(c *Config) { c.LabelPrefix = "example.com" },
+		"no providers":           func(c *Config) { c.Providers = nil },
+		"empty provider name":    func(c *Config) { c.Providers[0].Name = "" },
+		"empty secret keys":      func(c *Config) { c.Providers[0].SecretKeys = nil },
+		"empty secret key":       func(c *Config) { c.Providers[0].SecretKeys = []string{""} },
+		// The code has always checked this; the test never did.
+		"empty pattern": func(c *Config) { c.Providers[0].SecretNamePattern = "" },
+		"bad glob":      func(c *Config) { c.Providers[0].SecretNamePattern = "k3k-[" },
+		"duplicate provider names": func(c *Config) {
+			c.Providers = append(c.Providers, c.Providers[0])
+		},
+		// The name is written verbatim as a label value on every cluster Secret
+		// this provider matches. Accepted here, it would be rejected by the
+		// apiserver on every apply, forever, per cluster.
+		"provider name is not a valid label value": func(c *Config) {
+			c.Providers[0].Name = "my tool"
+		},
+		"provider name too long for a label value": func(c *Config) {
+			c.Providers[0].Name = strings.Repeat("a", 64)
+		},
+		"prefix without slash": func(c *Config) { c.LabelPrefix = "example.com" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := testConfig()
@@ -265,14 +458,14 @@ func TestDiscoverSkipsInvalidClusterNames(t *testing.T) {
 		managedNS("k3k-bad", "Prod_Cluster"),
 		kubeconfigSecret("k3k-bad", "k3k-bad-kubeconfig"),
 	)
-	children, complete, err := r.discover(context.Background())
+	children, unresolved, err := r.discover(context.Background())
 	if err != nil {
 		t.Fatalf("discover: %v", err)
 	}
 	if len(children) != 0 {
 		t.Errorf("expected the invalid name to be skipped, got %+v", children)
 	}
-	if complete {
-		t.Error("a skipped namespace must mark the pass incomplete so GC is suppressed")
+	if !unresolved["k3k-bad"] {
+		t.Error("a skipped namespace must be recorded as unresolved so its registration is exempt from GC")
 	}
 }


### PR DESCRIPTION
Config held a single secret-name pattern and a single key, so an instance could register k3k or vcluster and never both. The obvious workaround is a trap: two Deployments sharing a managedBy value garbage collect each other's Secrets, and giving them distinct values splits the fleet across two label namespaces and breaks the cluster-generator selector consumers rely on.

Replaces both scalars with a provider list tried in precedence order, and adds Kamaji and the Cluster API contract alongside the existing two. CAPI is the high-leverage entry: it is a mandatory control-plane contract rather than a convention, so one preset covers any CAPI cluster whatever the infrastructure provider, plus standalone k0smotron.

Pattern and keys travel together as a unit. That pairing is what tells a real kubeconfig from a decoy under the same prefix -- vcluster's `vc-*` matches both `vc-<name>` (key `config`) and `vc-config-<name>` (key `config.yaml`), and the decoy sorts first.

Discovery now collects candidates rather than stopping at the first match, and falls through on a parse failure. Matching a shape is not the same as being usable: CAPA's EKS path writes a second `<cluster>-user-kubeconfig` carrying an exec credential that cannot become an ArgoCD Secret at all. Falling through makes that harmless by construction instead of leaving it to depend on `k` sorting before `u`.

Fixes two pre-existing defects found while making room for the above:

  * Garbage collection was suppressed fleet-wide by any one namespace without a usable kubeconfig -- a single `complete` flag skipped collect() entirely, so one permanently broken namespace kept every other cluster's dead registration in ArgoCD indefinitely. Every k3k child hits this for its first ~90 seconds. Unevaluable namespaces are now exempted individually.

  * Propagated labels are copied over the ones apply() computes, and `source-namespace` was not withheld -- so a namespace labelling itself `<prefix>source-namespace: kube-system` produced a registration whose GC proof pointed at a namespace that never disappears, making it permanently uncollectable. All reserved suffixes are now withheld.

The deprecated --secret-name-pattern/--secret-key remain as a single-provider shorthand, gated on Flags().Changed rather than emptiness: both carry non-empty defaults, so testing the values would take the legacy branch every time and silently ignore the provider list. The chart renders one form or the other, never both.

Kamaji verified against v1.0.0: a real TenantControlPlane registered, and a kubeconfig rebuilt from the resulting ArgoCD Secret alone authenticated to the tenant API server with full x509 verification. The Kamaji-via-CAPI double-registration -- where the CAPI control-plane provider copies admin.conf into a second CAPI-shaped Secret, so both presets match one physical cluster -- was reproduced and produces exactly one registration.