### PR TITLE
feat: metrics, demoted-registration TTL, key-level fallthrough

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,13 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
+      # goreleaser has no SBOM generator of its own; it shells out to syft, and
+      # fails the release if it is missing. The images do not need this: ko
+      # generates their SPDX document natively, which is why only the binary
+      # archives were uncovered.
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+
       # Release notes come from CHANGELOG.md rather than from commit subjects,
       # so they are written deliberately and reviewed before tagging. A tag with
       # no matching section fails here instead of publishing an empty release.

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v6
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.22.9
         with:
           args: ./...

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v6
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.22.9
+        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
         with:
           args: ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,6 +172,29 @@ jobs:
       # The release workflow overrides it at package time so published charts were
       # fine, but `helm install` from a checkout pulled a stale image, and nothing
       # noticed because deploy-test overrides the tag explicitly.
+      # Both bind addresses become a containerPort by stripping the colon, so a
+      # host:port form renders containerPort 0 and a bare port hands the binary an
+      # address it cannot listen on. Neither should reach a cluster.
+      - name: A bind address that is not ":PORT" fails the render
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          for v in "0.0.0.0:8081" "8081" ""; do
+            if helm template t "$chart" --set probes.bindAddress="$v" >/dev/null 2>&1; then
+              echo "::error::probes.bindAddress=${v} rendered instead of failing"
+              exit 1
+            fi
+          done
+          if helm template t "$chart" --set metrics.enabled=true \
+               --set metrics.bindAddress=0.0.0.0:8080 >/dev/null 2>&1; then
+            echo "::error::metrics.bindAddress=0.0.0.0:8080 rendered instead of failing"
+            exit 1
+          fi
+          # The supported form still works, for both.
+          helm template t "$chart" --set probes.bindAddress=":9" >/dev/null
+          helm template t "$chart" --set metrics.enabled=true \
+            --set metrics.bindAddress=":9090" >/dev/null
+
       - name: The in-tree chart version is not behind the latest tag
         run: |
           set -euo pipefail

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,6 +172,23 @@ jobs:
       # The release workflow overrides it at package time so published charts were
       # fine, but `helm install` from a checkout pulled a stale image, and nothing
       # noticed because deploy-test overrides the tag explicitly.
+      # The chart derives the lease name in _helpers.tpl and the binary derives it
+      # in Go. If they drift, an instance deployed from a plain manifest and a
+      # chart-deployed one with identical configuration hold different leases while
+      # contending for the same cluster Secrets, and both reconcile. A Go test pins
+      # the same literal from the other side.
+      - name: The chart and the binary derive the same lease name
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          got=$(helm template t "$chart" --set leaderElection.enabled=true \
+            | grep -o 'leader-election-id=[a-z0-9-]*' | head -1 | cut -d= -f2)
+          want=acr-991221237547448b
+          if [ "$got" != "$want" ]; then
+            echo "::error::chart renders lease ${got}, the binary derives ${want}"
+            exit 1
+          fi
+
       # Both bind addresses become a containerPort by stripping the colon, so a
       # host:port form renders containerPort 0 and a bare port hands the binary an
       # address it cannot listen on. Neither should reach a cluster.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -747,23 +747,57 @@ jobs:
 
           kubectl delete namespace k3k-scope --wait=true
 
-      # The contested-name step above proves the refusal happens and keeps
-      # happening. This proves it is COUNTED, which is the half an operator can
-      # alert on. Deliberately a separate step rather than a replacement: the log
-      # count is what pins RequeueAfter, and losing it to a metric assertion would
-      # trade one signal for another.
+      # Proves a refusal is COUNTED, which is the half an operator can alert on.
+      # The contested-name step already proves refusals happen and keep happening,
+      # and that assertion stays: it is what pins RequeueAfter, and trading it for
+      # a metric would lose coverage rather than add it.
+      #
+      # Produces its own refusal rather than relying on that one. The downtime
+      # step above restarts the process, and a counter does not survive a restart.
       #
       # Scraped through port-forward rather than a curl pod: the image is
-      # distroless with no shell, and a second pod means an image pull in a job
-      # that already has one.
+      # distroless with no shell, and a second pod means another image pull.
       - name: A refused claim is counted under its own reason
         run: |
           set -euo pipefail
+          dep=deployment/registrar-argocd-cluster-registrar
+
+          # The holder registers FIRST, so the second claimant is refused as an
+          # incumbency rather than as a contested name.
+          kubectl create namespace k3k-holder
+          kubectl label namespace k3k-holder \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=metered
+          sed 's|https://192.0.2.10|https://192.0.2.71|' /tmp/kubeconfig.yaml > /tmp/holder.yaml
+          kubectl create secret generic k3k-holder-kubeconfig \
+            -n k3k-holder --from-file=kubeconfig.yaml=/tmp/holder.yaml
+          for i in $(seq 1 12); do
+            kubectl get secret cluster-metered -n argocd >/dev/null 2>&1 && break
+            sleep 5
+          done
+          kubectl get secret cluster-metered -n argocd >/dev/null || {
+            echo "::error::the holder never registered, so nothing would be refused"; exit 1; }
+
+          kubectl create namespace k3k-usurper
+          kubectl label namespace k3k-usurper \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=metered
+          sed 's|https://192.0.2.10|https://192.0.2.72|' /tmp/kubeconfig.yaml > /tmp/usurper.yaml
+          kubectl create secret generic k3k-usurper-kubeconfig \
+            -n k3k-usurper --from-file=kubeconfig.yaml=/tmp/usurper.yaml
+          for i in $(seq 1 12); do
+            kubectl logs -n registrar "$dep" | grep -q 'conflict=incumbent' && break
+            sleep 5
+          done
+          kubectl logs -n registrar "$dep" | grep -q 'conflict=incumbent' || {
+            echo "::error::the second claimant was never refused as an incumbency"
+            kubectl logs -n registrar "$dep" --tail=50; exit 1; }
+
           kubectl port-forward -n registrar svc/registrar-argocd-cluster-registrar-metrics 18080:8080 &
           pf=$!
           trap 'kill $pf 2>/dev/null || true' EXIT
           for i in $(seq 1 12); do
-            if curl -sf http://127.0.0.1:18080/metrics -o /tmp/metrics.txt; then break; fi
+            curl -sf http://127.0.0.1:18080/metrics -o /tmp/metrics.txt && break
             sleep 5
           done
           test -s /tmp/metrics.txt || { echo "::error::/metrics was never scrapeable"; exit 1; }
@@ -776,15 +810,27 @@ jobs:
             grep argocd_cluster_registrar /tmp/metrics.txt || true
             exit 1
           fi
-          # A refusal happened in the step above, so this cannot legitimately be 0.
           if [ "$(printf '%.0f' "$value")" -lt 1 ]; then
             echo "::error::a refusal was logged but never counted"
             grep argocd_cluster_registrar /tmp/metrics.txt || true
             exit 1
           fi
-          # The gauges come from the audit key, which is a different code path.
+          # Every other reason must be untouched, or a single mislabelled
+          # increment site would go unnoticed.
+          for other in contested_name create_race not_managed orphan_cluster_mismatch; do
+            v=$(awk -v s="reason=\"$other\"" '$0 ~ s {print $2}' /tmp/metrics.txt | tail -1)
+            if [ "$(printf '%.0f' "${v:-0}")" -ne 0 ]; then
+              echo "::error::an incumbency refusal also counted under reason=${other}"
+              grep argocd_cluster_registrar /tmp/metrics.txt || true
+              exit 1
+            fi
+          done
+          # The gauges come from the audit key, a different code path.
           grep -q 'argocd_cluster_registrar_registrations{state="active"}' /tmp/metrics.txt || {
             echo "::error::the registrations gauge was never set"; exit 1; }
+
+          kubectl delete namespace k3k-usurper k3k-holder --wait=true
+
 
       # Renaming demotes the old registration rather than deleting it. Worth doing
       # live because a real apiserver validates label values, and the demotion

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,6 +131,7 @@ jobs:
           helm lint "$chart" --set metrics.enabled=true
           helm lint "$chart" --set metrics.enabled=true --set metrics.service.enabled=true
           helm lint "$chart" --set metrics.enabled=true --set probes.enabled=false
+          helm lint "$chart" --set demotedTTL=720h
 
       # Two active replicas do not corrupt each other, but they do the work twice
       # and rewrite each other's provider label when configured differently.
@@ -218,6 +219,24 @@ jobs:
             echo "::error::default install should defer to the binary's own default"
             grep -- '--' <<<"$out"; exit 1
           fi
+
+      # `0s` is a truthy string in a Go template and `0` is a falsy int, so a
+      # conditional here renders opposite results for the same intent. The flag is
+      # emitted unconditionally; this pins that.
+      - name: demotedTTL renders the same disabled value however it is spelled
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          for v in "" "--set demotedTTL=0" "--set demotedTTL=0s"; do
+            got=$(helm template t "$chart" $v | grep -o -- '--demoted-ttl=[^"]*')
+            if [ "$got" != "--demoted-ttl=0s" ]; then
+              echo "::error::demotedTTL ${v:-<default>} rendered ${got}, want --demoted-ttl=0s"
+              exit 1
+            fi
+          done
+          helm template t "$chart" --set demotedTTL=720h \
+            | grep -q -- '--demoted-ttl=720h' || {
+            echo "::error::a configured demotedTTL did not reach the pod"; exit 1; }
 
       # An empty --metrics-bind-address means ":8080" to controller-runtime, not
       # "off", so the default install must emit no such flag at all rather than an

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,10 +65,32 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # envtest, so the tests that need a real apiserver are not silently skipped.
+      # Pinned to controller-runtime's release branch rather than @latest: the
+      # tool and the library move together.
+      - name: Set up envtest
+        run: |
+          set -euo pipefail
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
+          echo "KUBEBUILDER_ASSETS=$(setup-envtest use -p path)" >> "$GITHUB_ENV"
+
       # There was no test step at all before, while the destructive paths
       # (garbage collection especially) carry the tests that matter most.
       - name: Test
         run: go test -race -cover ./...
+
+      # A test that skips is indistinguishable from a test that passes, and the
+      # envtest cases skip themselves when KUBEBUILDER_ASSETS is unset. So assert
+      # they RAN, rather than trusting the exit code of the step above.
+      - name: The envtest cases actually ran
+        run: |
+          set -euo pipefail
+          go test ./internal/registrar/ -run 'TestAStranded' -v -timeout 5m | tee /tmp/envtest.log
+          if ! grep -q -- '--- PASS: TestAStrandedRegistrationIsCollectedOnStartup' /tmp/envtest.log; then
+            echo "::error::the envtest case did not run; it was skipped or renamed"
+            grep -E -- '--- (PASS|SKIP|FAIL)' /tmp/envtest.log || true
+            exit 1
+          fi
 
       # Metrics were deferred for a release because securing the endpoint pulls in
       # k8s.io/apiserver and its cel-go/gRPC/OTel arm. One import of
@@ -639,6 +661,74 @@ jobs:
             exit 1
           fi
           kubectl delete namespace aaa-second --wait=true
+
+      # A namespace deleted while nothing was running produces no event to catch
+      # up on, so the startup seeder is the only thing that finds its
+      # registration. Proven under envtest too, but here with real RBAC: the
+      # seeder rebuilds its key set by LISTing owned Secrets, which the covering
+      # role must actually permit.
+      - name: A registration orphaned while the pod was down is collected on startup
+        run: |
+          set -euo pipefail
+          dep=deployment/registrar-argocd-cluster-registrar
+          kubectl create namespace k3k-downtime
+          kubectl label namespace k3k-downtime \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=downtime
+          sed 's|https://192.0.2.10|https://192.0.2.51|' /tmp/kubeconfig.yaml > /tmp/downtime.yaml
+          kubectl create secret generic k3k-downtime-kubeconfig \
+            -n k3k-downtime --from-file=kubeconfig.yaml=/tmp/downtime.yaml
+          for i in $(seq 1 12); do
+            kubectl get secret cluster-downtime -n argocd >/dev/null 2>&1 && break
+            sleep 5
+          done
+          kubectl get secret cluster-downtime -n argocd >/dev/null
+
+          # Down, THEN delete: the whole point is that no watch event is delivered.
+          kubectl scale deployment -n registrar registrar-argocd-cluster-registrar --replicas=0
+          kubectl wait --for=delete pod -n registrar \
+            -l app.kubernetes.io/name=argocd-cluster-registrar --timeout=2m
+          kubectl delete namespace k3k-downtime --wait=true
+          kubectl get secret cluster-downtime -n argocd >/dev/null || {
+            echo "::error::the registration vanished while nothing was running"; exit 1; }
+
+          kubectl scale deployment -n registrar registrar-argocd-cluster-registrar --replicas=1
+          kubectl rollout status -n registrar "$dep" --timeout=2m
+          for i in $(seq 1 12); do
+            if ! kubectl get secret cluster-downtime -n argocd >/dev/null 2>&1; then
+              echo "collected after $((i*5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::a registration orphaned during downtime was never collected"
+          kubectl logs -n registrar "$dep" --tail=50
+          exit 1
+
+      # Taking a namespace out of scope is not a deletion, and a label-filtered
+      # cache cannot tell the two apart: the apiserver reports an object that
+      # stops matching the selector as a synthetic Delete. This is the scenario
+      # where making the existence proof a cached read would deregister a live
+      # cluster fleet-wide, which is why the proof goes to the apiserver.
+      #
+      # A broad regression guard rather than a sharp one: it is here to fail if
+      # that read is ever switched to the cache, not to catch a one-line slip.
+      - name: Removing the ownership label does not deregister anything
+        run: |
+          set -euo pipefail
+          dep=deployment/registrar-argocd-cluster-registrar
+          kubectl get secret cluster-capichild -n argocd >/dev/null
+          kubectl label namespace capi-child argocd-cluster-registrar/managed-by-
+          # Longer than interval=5s, so several reconciles see the namespace
+          # out of scope rather than none.
+          sleep 20
+          kubectl get secret cluster-capichild -n argocd >/dev/null || {
+            echo "::error::a registration was deleted when its namespace left scope"
+            kubectl logs -n registrar "$dep" --tail=50; exit 1; }
+          kubectl logs -n registrar "$dep" | grep -q 'no longer carries the ownership label' || {
+            echo "::error::the namespace left scope without the controller noticing"
+            kubectl logs -n registrar "$dep" --tail=50; exit 1; }
+          kubectl label namespace capi-child argocd-cluster-registrar/managed-by=cluster-registrar
 
       # The contested-name step above proves the refusal happens and keeps
       # happening. This proves it is COUNTED, which is the half an operator can

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -532,10 +532,23 @@ jobs:
           done
           kubectl get secret cluster-audited -n argocd >/dev/null
 
-          # Delete the namespace FIRST. While it exists, its own reconcile reaches
-          # the orphan-adoption branch, restores source-namespace within seconds,
-          # and the Secret is routable again before the audit ever looks at it.
+          # Pin it BEFORE deleting the namespace. Deletion is event-driven, so the
+          # controller collects the registration within a second or two of the
+          # namespace going away, and it was racing the label command below: the
+          # step failed intermittently on a NotFound that had nothing to do with
+          # what it was testing. prune=disabled is checked ahead of every removal
+          # path, so this closes the window rather than widening it.
+          kubectl label secret cluster-audited -n argocd \
+            argocd-cluster-registrar/prune=disabled
+
+          # Delete the namespace before stripping source-namespace. While it
+          # exists, its own reconcile reaches the orphan-adoption branch, restores
+          # the label within seconds, and the Secret is routable again before the
+          # audit ever looks at it.
           kubectl delete namespace k3k-audit --wait=true
+          sleep 10
+          kubectl get secret cluster-audited -n argocd >/dev/null || {
+            echo "::error::a pinned registration was collected anyway"; exit 1; }
           kubectl label secret cluster-audited -n argocd \
             argocd-cluster-registrar/source-namespace-
           kubectl rollout restart deployment -n registrar registrar-argocd-cluster-registrar

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -709,26 +709,43 @@ jobs:
       # cache cannot tell the two apart: the apiserver reports an object that
       # stops matching the selector as a synthetic Delete. This is the scenario
       # where making the existence proof a cached read would deregister a live
-      # cluster fleet-wide, which is why the proof goes to the apiserver.
+      # cluster fleet-wide, which is why that proof goes to the apiserver.
       #
       # A broad regression guard rather than a sharp one: it is here to fail if
       # that read is ever switched to the cache, not to catch a one-line slip.
+      #
+      # Creates its own namespace. Borrowing capi-child does not work: the
+      # half-written-kubeconfig step deletes it to prove GC still runs, so by here
+      # both it and its registration are long gone.
       - name: Removing the ownership label does not deregister anything
         run: |
           set -euo pipefail
           dep=deployment/registrar-argocd-cluster-registrar
-          kubectl get secret cluster-capichild -n argocd >/dev/null
-          kubectl label namespace capi-child argocd-cluster-registrar/managed-by-
-          # Longer than interval=5s, so several reconciles see the namespace
-          # out of scope rather than none.
+          kubectl create namespace k3k-scope
+          kubectl label namespace k3k-scope \
+            argocd-cluster-registrar/managed-by=cluster-registrar \
+            argocd-cluster-registrar/cluster=scoped
+          sed 's|https://192.0.2.10|https://192.0.2.61|' /tmp/kubeconfig.yaml > /tmp/scope.yaml
+          kubectl create secret generic k3k-scope-kubeconfig \
+            -n k3k-scope --from-file=kubeconfig.yaml=/tmp/scope.yaml
+          for i in $(seq 1 12); do
+            kubectl get secret cluster-scoped -n argocd >/dev/null 2>&1 && break
+            sleep 5
+          done
+          kubectl get secret cluster-scoped -n argocd >/dev/null || {
+            echo "::error::the fixture never registered, so this proves nothing"; exit 1; }
+
+          kubectl label namespace k3k-scope argocd-cluster-registrar/managed-by-
+          # Longer than interval=5s, so several reconciles see it out of scope.
           sleep 20
-          kubectl get secret cluster-capichild -n argocd >/dev/null || {
+          kubectl get secret cluster-scoped -n argocd >/dev/null || {
             echo "::error::a registration was deleted when its namespace left scope"
             kubectl logs -n registrar "$dep" --tail=50; exit 1; }
           kubectl logs -n registrar "$dep" | grep -q 'no longer carries the ownership label' || {
             echo "::error::the namespace left scope without the controller noticing"
             kubectl logs -n registrar "$dep" --tail=50; exit 1; }
-          kubectl label namespace capi-child argocd-cluster-registrar/managed-by=cluster-registrar
+
+          kubectl delete namespace k3k-scope --wait=true
 
       # The contested-name step above proves the refusal happens and keeps
       # happening. This proves it is COUNTED, which is the half an operator can

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,20 @@ jobs:
       - name: Test
         run: go test -race -cover ./...
 
+      # Metrics were deferred for a release because securing the endpoint pulls in
+      # k8s.io/apiserver and its cel-go/gRPC/OTel arm. One import of
+      # controller-runtime's pkg/metrics/filters brings all of it back, so assert
+      # the absence rather than trusting review. -deps excludes test-only imports,
+      # which is why an envtest dependency cannot trip this.
+      - name: The apiserver authn/authz arm stays out of the binary
+        run: |
+          set -euo pipefail
+          if go list -deps ./... | grep -q '^k8s.io/apiserver'; then
+            echo "::error::k8s.io/apiserver is linked; pkg/metrics/filters was probably imported"
+            go list -deps ./... | grep '^k8s.io/apiserver' | head -20
+            exit 1
+          fi
+
   chart:
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -113,6 +127,10 @@ jobs:
           helm lint "$chart" --set leaderElection.enabled=true
           helm lint "$chart" --set probes.enabled=false
           helm lint "$chart" --set replicaCount=2 --set leaderElection.enabled=true
+          # The 0.5.0 operational surface.
+          helm lint "$chart" --set metrics.enabled=true
+          helm lint "$chart" --set metrics.enabled=true --set metrics.service.enabled=true
+          helm lint "$chart" --set metrics.enabled=true --set probes.enabled=false
 
       # Two active replicas do not corrupt each other, but they do the work twice
       # and rewrite each other's provider label when configured differently.
@@ -199,6 +217,46 @@ jobs:
           if grep -qE -- '--provider=|--secret-name-pattern=|--secret-key=' <<<"$out"; then
             echo "::error::default install should defer to the binary's own default"
             grep -- '--' <<<"$out"; exit 1
+          fi
+
+      # An empty --metrics-bind-address means ":8080" to controller-runtime, not
+      # "off", so the default install must emit no such flag at all rather than an
+      # empty one. Nor a Service, which would put a stable name in front of an
+      # unauthenticated port nobody asked for.
+      - name: A default install serves no metrics
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          out=$(helm template t "$chart")
+          if grep -q -- '--metrics-bind-address' <<<"$out"; then
+            echo "::error::the default install passes a metrics bind address"
+            grep -- '--' <<<"$out"; exit 1
+          fi
+          if grep -q '^kind: Service$' <<<"$out"; then
+            echo "::error::the default install renders a Service"
+            exit 1
+          fi
+
+      # And when asked for, all three parts must appear together: the flag, the
+      # container port the Service targets by name, and the Service itself.
+      - name: Enabling metrics renders the flag, the port and the Service
+        run: |
+          set -euo pipefail
+          chart=deploy/charts/argocd-cluster-registrar
+          out=$(helm template t "$chart" \
+            --set metrics.enabled=true --set metrics.service.enabled=true)
+          grep -q -- '--metrics-bind-address=:8080' <<<"$out" || {
+            echo "::error::metrics were enabled but no bind address was passed"; exit 1; }
+          grep -q 'name: metrics' <<<"$out" || {
+            echo "::error::no metrics container port"; exit 1; }
+          grep -q '^kind: Service$' <<<"$out" || {
+            echo "::error::no Service"; exit 1; }
+          # Rendering the ports key twice yields a manifest where the second one
+          # silently wins, which is what a naive second entry under the probes
+          # conditional would have produced.
+          if [ "$(grep -c '^          ports:$' <<<"$out")" != "1" ]; then
+            echo "::error::the container has more than one ports: key"
+            exit 1
           fi
 
   deploy-test:
@@ -299,6 +357,8 @@ jobs:
             --set 'providers[0]=k3k' \
             --set 'providers[1]=capi' \
             --set interval=5s \
+            --set metrics.enabled=true \
+            --set metrics.service.enabled=true \
             --wait --timeout 3m
 
       # Assertions are real: no `|| echo "Ignored..."`, so a regression fails CI.
@@ -560,6 +620,45 @@ jobs:
             exit 1
           fi
           kubectl delete namespace aaa-second --wait=true
+
+      # The contested-name step above proves the refusal happens and keeps
+      # happening. This proves it is COUNTED, which is the half an operator can
+      # alert on. Deliberately a separate step rather than a replacement: the log
+      # count is what pins RequeueAfter, and losing it to a metric assertion would
+      # trade one signal for another.
+      #
+      # Scraped through port-forward rather than a curl pod: the image is
+      # distroless with no shell, and a second pod means an image pull in a job
+      # that already has one.
+      - name: A refused claim is counted under its own reason
+        run: |
+          set -euo pipefail
+          kubectl port-forward -n registrar svc/registrar-argocd-cluster-registrar-metrics 18080:8080 &
+          pf=$!
+          trap 'kill $pf 2>/dev/null || true' EXIT
+          for i in $(seq 1 12); do
+            if curl -sf http://127.0.0.1:18080/metrics -o /tmp/metrics.txt; then break; fi
+            sleep 5
+          done
+          test -s /tmp/metrics.txt || { echo "::error::/metrics was never scrapeable"; exit 1; }
+
+          series='argocd_cluster_registrar_conflicts_total{reason="incumbent"}'
+          value=$(awk -v s="$series" '$0 ~ s {print $2}' /tmp/metrics.txt | tail -1)
+          echo "$series = ${value:-<absent>}"
+          if [ -z "${value:-}" ]; then
+            echo "::error::the conflict counter is absent; it must be published at zero from startup"
+            grep argocd_cluster_registrar /tmp/metrics.txt || true
+            exit 1
+          fi
+          # A refusal happened in the step above, so this cannot legitimately be 0.
+          if [ "$(printf '%.0f' "$value")" -lt 1 ]; then
+            echo "::error::a refusal was logged but never counted"
+            grep argocd_cluster_registrar /tmp/metrics.txt || true
+            exit 1
+          fi
+          # The gauges come from the audit key, which is a different code path.
+          grep -q 'argocd_cluster_registrar_registrations{state="active"}' /tmp/metrics.txt || {
+            echo "::error::the registrations gauge was never set"; exit 1; }
 
       # Renaming demotes the old registration rather than deleting it. Worth doing
       # live because a real apiserver validates label values, and the demotion

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,13 @@ archives:
 snapshot:
   version_template: "{{.Tag}}-next"
 
+# One SPDX document per archive. The images already carry one: ko generates it
+# natively (kos.sbom defaults to spdx), which is why only the archives were
+# uncovered. goreleaser has no built-in generator and shells out to syft, so the
+# release workflow installs it.
+sboms:
+  - artifacts: archive
+
 checksum:
   name_template: "{{.ProjectName}}_{{.Version}}_SHA256SUMS"
   algorithm: sha256

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,7 +77,10 @@ kos:
     preserve_import_paths: false
     tags:
       - "{{.Version}}"
-      - latest
+      # Not on a prerelease. Cutting v0.6.0-rc1 would otherwise republish latest
+      # pointing at a release candidate, and the people tracking latest are
+      # exactly the ones not using the chart, which pins a version.
+      - "{{ if not .Prerelease }}latest{{ end }}"
 
 docker_signs:
   - id: server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,19 @@ served or deleted unless you ask for it.
   a name produced a registration with the right CA and the right credentials that
   still failed hostname verification.
 
+- **An empty `--label-prefix` is rejected rather than silently repaired.** With no
+  prefix, label propagation matched every label on the source namespace and the
+  reserved set computed as bare names matching nothing actually written, so a
+  tenant could propagate `argocd.argoproj.io/secret-type` off its own namespace.
+  The constructor defaulted it, so this was unreachable through the CLI or the
+  chart, but validation and defaulting disagreeing is how it stops being
+  unreachable.
+
+- **A `bindAddress` that is not `:PORT` now fails the chart render, naming the
+  key.** The container port is derived by stripping the colon, so `0.0.0.0:8081`
+  rendered `containerPort: 0` and a bare `8081` handed the binary an address it
+  could not listen on. Both failed, neither said why.
+
 - **A `--label-prefix` that ArgoCD's own key falls under is rejected.** Under
   `argocd.argoproj.io/`, a source namespace could propagate
   `argocd.argoproj.io/secret-type`, which is not a reserved suffix, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,10 @@ served or deleted unless you ask for it.
   using the chart. Set the flag explicitly to override. Only affects installs with
   `leaderElection` enabled, which is off by default.
 
+- **An SPDX SBOM ships alongside each binary archive.** The images already had
+  one, generated natively by ko, so only the archives were uncovered. Verified by
+  a local snapshot build: eight documents, 57 packages each.
+
 - **Errors are printed once.** `main` wrapped every failure in a second message on
   a second stream in a different format, while cobra had already printed it, and
   the wording was inherited from `vcluster-argocd-exporter` so a flag validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,133 @@ All notable changes to **argocd-cluster-registrar** are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-07
+
+Closes the four things 0.4.0 deliberately left open: metrics, a TTL for demoted
+registrations, key-level fallthrough on kubeconfig `Secret`s, and the absence of
+any test driving a real manager.
+
+Upgrading needs no configuration change, no RBAC change, and nothing new is
+served or deleted unless you ask for it.
+
+### Added
+
+- **Prometheus metrics, off by default.** Four series, all counts of this
+  instance's own decisions:
+
+  | Metric | |
+  |---|---|
+  | `argocd_cluster_registrar_conflicts_total{reason}` | registrations refused, by which check refused them |
+  | `argocd_cluster_registrar_adoptions_total` | orphaned `Secret`s adopted by a matching namespace |
+  | `argocd_cluster_registrar_registrations{state}` | registrations owned, `active` or `demoted` |
+  | `argocd_cluster_registrar_unrouted_secrets` | owned `Secret`s no reconcile key can reach |
+
+  `conflicts_total{reason="incumbent"}` is the one worth alerting on: a contested
+  cluster name persists until a human resolves it, and until now the only signal
+  was a log line. `reason="create_race"` is benign and expected during a
+  leader-election handover; do not alert on it.
+
+  The counters are published at zero from startup, because an unincremented
+  counter is absent from `/metrics` entirely and an absent series makes
+  `increase(...[15m]) > 0` unevaluable rather than false.
+
+  Enable with `metrics.enabled`, which opens the port on the pod;
+  `metrics.service.enabled` additionally renders a `Service`. **The endpoint is
+  unauthenticated**, so put a `NetworkPolicy` in front of it. Securing it properly
+  means controller-runtime's authn/authz filter, which links `k8s.io/apiserver`
+  and its cel-go/gRPC/OpenTelemetry arm and needs `tokenreviews` and
+  `subjectaccessreviews` RBAC; nothing published carries a cluster name, a
+  namespace or a credential, so that trade was not worth making. No
+  `ServiceMonitor` ships: it needs a CRD `helm template` cannot check for, so it
+  could not be proven correct in CI.
+
+  **Which** cluster is contested stays in the log line, which names it along with
+  both namespaces, and it is not coming to the metrics. Those values are read off
+  objects a tenant creates, so as labels they are unbounded cardinality anyone
+  able to label a namespace could mint, on the one code path that exists because
+  somebody may be acting in bad faith. A per-conflict gauge would also be
+  unclearable: when the losing claimant's namespace is deleted, the reconcile
+  takes the `NotFound` branch and never reaches the code that would zero it, so it
+  would alert forever about a conflict that no longer exists.
+
+- **`demotedTTL`, off by default.** A renamed cluster leaves its old registration
+  demoted rather than deleted, so the rename can be undone. Nothing ever cleaned
+  those up: they accumulated until their source namespace was deleted, and they
+  held the old cluster name against any other claimant for exactly as long.
+
+  Setting `demotedTTL` deletes them once they have been superseded that long,
+  which also frees the name they were holding, so a namespace refused for that
+  name starts succeeding. It is opt-in because the TTL is equally a deadline on
+  reverting a rename.
+
+  Expiry is deliberately narrow. It runs only when the source namespace is alive
+  and has registered under a different name, never while it is terminating or
+  undiscoverable, and never sooner than `interval`. `<labelPrefix>prune: disabled`
+  exempts a registration from it, as from the other two removal paths.
+
+### Fixed
+
+- **Every key present on a kubeconfig `Secret` is now tried, in declared order.**
+  Discovery stopped at the first key a `Secret` carried, so each provider/`Secret`
+  pair produced exactly one candidate. Kamaji ships `admin.conf` and `admin.svc`
+  together, so a half-written or otherwise unusable `admin.conf` put `admin.svc`
+  out of reach and left the namespace unregistered for as long as it stayed that
+  way, with a working kubeconfig sitting beside it. `Provider.SecretKeys`
+  documented its keys as "tried in order" throughout.
+
+  Fallthrough across `Secret`s already worked and is unchanged; this extends the
+  same mechanism within one. Scope worth being plain about: both Kamaji keys
+  normally parse, so `admin.conf` still wins on a healthy install. This makes the
+  declared order real rather than changing which key anyone uses today.
+
+- **A repeated key in a provider spec is now rejected at startup** instead of
+  parsing the same bytes twice, matching how a duplicate provider name is already
+  handled.
+
+### Changed
+
+- The `--dry-run` de-escalation of `--leader-elect` no longer writes back into the
+  flag variable. No user-visible effect; it made the flag mapping untestable and
+  leaked state across cases in the test binary.
+
+- The README no longer restates the chart's values. Nine keys were documented in
+  two places while twenty-three existed, so `leaderElection`, `probes`,
+  `replicaCount` and `resources` read as though they were not configurable. Use
+  `helm show values`. The architecture notes moved to
+  [docs/architecture.md](docs/architecture.md), where they can grow without
+  standing between a reader and the install instructions.
+
+### Internal
+
+- A test now drives a real manager under envtest. The startup seeder had no
+  coverage anywhere: removing it leaves every other test passing while a
+  registration orphaned during downtime survives forever with no symptom. Two kind
+  steps cover the same ground against real RBAC.
+
+- CI asserts `k8s.io/apiserver` stays out of the binary. One import of
+  controller-runtime's metrics filter brings the whole arm back, and that cost is
+  the entire reason metrics were deferred a release.
+
+### Migrating from 0.4.x
+
+Nothing to change. No RBAC change, no value changes meaning, and the two new
+features are both off until you turn them on.
+
+1. **Metrics are off.** `metrics.enabled` opens an unauthenticated port on the
+   pod; pair it with a `NetworkPolicy`. `metrics.service.enabled` is a separate
+   switch for the `Service`.
+
+2. **`demotedTTL` is `0s`, meaning never.** Existing demoted registrations are
+   untouched until you set it. When you do, remember it is also how long a
+   mistaken rename stays revertible.
+
+3. **Discovery may now find a cluster it previously could not.** If a namespace
+   was stuck unregistered because the first key on its `Secret` was unusable, it
+   will register on first reconcile after upgrade. That is the fix working.
+
+4. **A duplicated `secretKeys` entry now fails at startup** rather than being
+   quietly tolerated. It has never done anything useful; remove the duplicate.
+
 ## [0.4.0] - 2026-08-07
 
 A controller. Registration and removal now follow namespace events instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,35 @@ served or deleted unless you ask for it.
   parsing the same bytes twice, matching how a duplicate provider name is already
   handled.
 
+- **`<labelPrefix>prune: disabled` now works on an active registration.** It was
+  swept off by the same cleanup that removes a label deleted upstream, because it
+  has no upstream to be absent from. `changed()` also read the pin as drift, so the
+  update that stripped it ran even when nothing else had moved: the operator set
+  the label, the API accepted it, and it was gone within one `interval`. That is
+  the documented case, and it silently did not work. Present since the opt-out
+  shipped in 0.4.0.
+
+  Every existing test pinned a `Secret` that `apply` never touches, which is why
+  five of them passed throughout. The demotion labels are still swept, since that
+  is what restores a registration when a rename is reverted.
+
+- **A registration whose deletion loses its UID precondition is no longer
+  abandoned.** The delete leaves the `Secret` in place on purpose, but it was
+  counted as removed, which retired the reconcile key. The source namespace is
+  gone by then, so nothing could ever enqueue it again and the registration
+  outlived its cluster until the process restarted. That discarded exactly the
+  recovery the precondition was added for.
+
+- **`tls-server-name` is carried into the cluster `Secret`.** It was parsed by
+  nothing and dropped, so a kubeconfig reached by IP with a certificate issued for
+  a name produced a registration with the right CA and the right credentials that
+  still failed hostname verification.
+
+- **A `--label-prefix` that ArgoCD's own key falls under is rejected.** Under
+  `argocd.argoproj.io/`, a source namespace could propagate
+  `argocd.argoproj.io/secret-type`, which is not a reserved suffix, and the
+  propagated labels are copied last, so it would override the key this tool sets.
+
 ### Changed
 
 - The `--dry-run` de-escalation of `--leader-elect` no longer writes back into the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,20 @@ served or deleted unless you ask for it.
   a name produced a registration with the right CA and the right credentials that
   still failed hostname verification.
 
+- **`--leader-election-id` now defaults to the same lease the chart derives.** The
+  chart computes it from `labelPrefix` and `managedBy`, because those are what
+  decide whether two instances contend for the same cluster `Secret`s; the binary
+  defaulted to a constant. So an instance deployed from a plain manifest and a
+  chart-deployed one with identical configuration held *different* leases and both
+  reconciled, which is the state leader election exists to prevent, reached by not
+  using the chart. Set the flag explicitly to override. Only affects installs with
+  `leaderElection` enabled, which is off by default.
+
+- **Errors are printed once.** `main` wrapped every failure in a second message on
+  a second stream in a different format, while cobra had already printed it, and
+  the wording was inherited from `vcluster-argocd-exporter` so a flag validation
+  error read as a failure to export clusters.
+
 - **An empty `--label-prefix` is rejected rather than silently repaired.** With no
   prefix, label propagation matched every label on the source namespace and the
   reserved set computed as bare names matching nothing actually written, so a

--- a/README.md
+++ b/README.md
@@ -164,16 +164,20 @@ The matched provider is recorded on the cluster `Secret` as
 
 #### Per-provider notes
 
-**Order matters.** The globs overlap on purpose: `capi`'s `*-kubeconfig` also
-matches k3k's `k3k-<cluster>-kubeconfig`. Correctness comes from the key, not the
-name, and where two providers could both claim a `Secret` the one declared first
-wins. Put the more specific provider first. `capi` is the loosest shipped.
+**Order matters,** for providers and for keys. The globs overlap on purpose:
+`capi`'s `*-kubeconfig` also matches k3k's `k3k-<cluster>-kubeconfig`. Correctness
+comes from the key, not the name, and where two providers could both claim a
+`Secret` the one declared first wins. Put the more specific provider first. `capi`
+is the loosest shipped. Within one `Secret`, every declared key that is present is
+tried in turn and the first that parses wins, so an unusable key falls through to
+the next instead of stranding the namespace.
 
-**Kamaji** normally writes both `admin.conf` and `admin.svc`. Only the first key
-present is tried, so `admin.conf` wins; reorder them in a custom entry if you need
-the other. Running Kamaji through its Cluster API control-plane provider produces
-a second, CAPI-shaped `Secret` for the same cluster, so with both presets enabled
-the one declared first decides which is used.
+**Kamaji** normally writes both `admin.conf` and `admin.svc`, and both normally
+parse, so `admin.conf` wins on order and `admin.svc` is reached only when the
+first is unusable. Declare `admin.svc` first in a custom entry to prefer the
+service address. Running Kamaji through its Cluster API control-plane provider
+produces a second, CAPI-shaped `Secret` for the same cluster, so with both presets
+enabled the one declared first decides which is used.
 
 **`capi`** is the mandatory control-plane contract, so it covers any CAPI cluster
 whatever the infrastructure provider, plus standalone k0smotron. It does **not**

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ dryRun: false
 # Verbose logging.
 debug: false
 
+# Expire demoted registrations after this long. 0s keeps them. See "Operating".
+demotedTTL: 0s
+
 # Prometheus metrics. Off by default, unauthenticated when on. See "Operating".
 metrics:
   enabled: false
@@ -300,6 +303,7 @@ stateDiagram-v2
     Pinned --> Registered: label removed
     Registered --> [*]: source namespace deleted<br/>cluster Secret removed
     Demoted --> [*]: source namespace deleted
+    Demoted --> [*]: demotedTTL elapsed (opt-in)
 ```
 
 Cluster `Secret`s that carry the ownership label but whose source namespace has
@@ -316,6 +320,13 @@ nothing is destroyed. Change the label back and the registration returns intact,
 so a mistaken rename costs nothing. It also keeps the old cluster name reserved,
 which is what makes that revert possible; delete it if a different namespace
 should take that name.
+
+Demoted registrations otherwise accumulate until their namespace is deleted. Set
+`demotedTTL` to expire them, which also frees the name they hold. It is `0s`
+(never) by default, since the TTL is equally a deadline on reverting a rename.
+Expiry only reaches a namespace that is alive and registered under another name,
+never one that is terminating or undiscoverable, and never sooner than
+`interval`. `prune: disabled` exempts a registration from this too.
 
 RBAC is split by scope. Reads are cluster-wide (`namespaces` get/list/watch,
 `secrets` **list only**) because discovery is label-driven and the sources sit in

--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ instance's own decisions:
 | `..._registrations{state}` | registrations owned, `active` or `demoted` |
 | `..._unrouted_secrets` | owned `Secret`s no reconcile key can reach |
 
+Aggregate the two gauges across replicas (`sum by`, `max by`). They are set only
+by the reconcile that audits, so a leader-election standby serves them as zero for
+as long as it stands by, and a bare threshold or an `avg` quietly stops firing.
+
 `conflicts_total{reason="incumbent"}` is the one worth alerting on: a contested
 name stays contested until someone resolves it. *Which* cluster is in the log
 line, not the labels, so a tenant cannot mint series by naming a namespace.

--- a/README.md
+++ b/README.md
@@ -83,49 +83,34 @@ helm upgrade <release_name> --install \
 
 ### Values
 
+Everything is optional. A default install registers k3k clusters into `argocd`:
+
 ```yaml
-# Namespace ArgoCD reads cluster Secrets from. ArgoCD only looks in its own
-# namespace, so in practice this is always "argocd".
+# Provisioners to look for, in precedence order. Presets: k3k, vcluster, kamaji,
+# capi. Unset means k3k. See "Providers" below.
+providers:
+  - k3k
+  - capi
+
+# Namespace ArgoCD reads cluster Secrets from.
 targetNamespace: argocd
 
-# Prefix for the labels read off the source namespace and copied onto the cluster
-# Secret. Change it to match an existing labelling convention.
-labelPrefix: argocd-cluster-registrar/
-
-# Value of the `<labelPrefix>managed-by` label. It picks which namespaces to
-# watch, and which cluster Secrets this release owns. Give each instance its own.
+# Picks which namespaces to watch and which cluster Secrets this release owns.
+# Give each instance its own.
 managedBy: cluster-registrar
-
-# Provisioners to look for, in precedence order. Presets: k3k, vcluster, kamaji,
-# capi. Empty means the binary's own default, which is k3k. See "Providers" below.
-providers: []
-
-# How long before a settled cluster is looked at again. NOT how quickly a new one
-# is registered: that follows the namespace event. This bounds credential
-# freshness after a certificate rotation.
-interval: 60s
-
-# Log what would change without writing anything. Useful the first time you point
-# this at an existing cluster, to check the GC selector matches only what you expect.
-dryRun: false
-
-# Verbose logging.
-debug: false
-
-# Expire demoted registrations after this long. 0s keeps them. See "Operating".
-demotedTTL: 0s
-
-# Prometheus metrics. Off by default, unauthenticated when on. See "Operating".
-metrics:
-  enabled: false
 ```
 
-The binary also falls back to your own kubeconfig when it is not running in a
-cluster, so you can try it before installing anything:
+Every key is documented in the chart itself, which is the copy that cannot drift
+from the code:
 
 ```bash
-argocd-cluster-registrar --once --dry-run --debug
+helm show values oci://ghcr.io/pcanilho/charts/argocd-cluster-registrar
 ```
+
+The ones worth knowing about are `interval`, `demotedTTL`, `leaderElection`,
+`probes` and `metrics`; see [Operating](#operating). You can also try it against
+a live cluster before installing anything, with
+[`--once`](#running-it-without-installing-anything).
 
 ### Providers
 
@@ -334,8 +319,8 @@ one namespace per child. Every **write** is a namespaced `Role` bound to
 `targetNamespace` alone, since that is the only place this ever creates, updates
 or deletes anything. Granting `secrets` write across the whole cluster would be a
 privilege-escalation path in exchange for nothing. Note `watch` is granted on
-namespaces only: see Architecture below for why the kubeconfig `Secret`s are read
-rather than watched.
+namespaces only; [docs/architecture.md](docs/architecture.md) covers why the
+kubeconfig `Secret`s are read rather than watched.
 
 ## Operating
 
@@ -385,28 +370,6 @@ anything. It is the quickest way to see what this would do to an existing
 cluster, and the easiest way to reproduce a decision the running controller made
 without disturbing it. `--dry-run` also disables leader election, so a pre-flight
 check can never take the running instance offline.
-
-### Architecture
-
-Two decisions here are deliberate and look like oversights.
-
-**Only namespaces are watched.** Not the provisioner-written kubeconfig
-`Secret`s, even though watching them would spot a credential rotation sooner.
-k3k regenerates the child's keypair on *every one of its own reconciles*, so
-that `Secret` changes far more often than the credential meaningfully does. The
-interval is what keeps that from becoming a write per k3k reconcile against a
-credential-bearing `Secret` in the ArgoCD namespace, each of which invalidates
-ArgoCD's own cluster cache. Such a watch could not be narrowed either: the
-provisioner owns that `Secret`, so it carries none of our labels, which is the
-same reason discovery is driven by the namespace in the first place.
-
-**Nothing is read through the controller's cache.** Every read goes direct. The
-namespace existence proof in particular must not be cached, because a
-label-filtered cache reports an object that stops matching the selector as a
-deletion -- so a cached `NotFound` cannot tell a deleted namespace from one that
-merely lost a label, and deregistering on the second would be catastrophic. The
-cache is configured to error rather than silently start an informer for anything
-unexpected, and no `Secret` is ever held in it.
 
 ### Who is allowed to set these labels
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ dryRun: false
 
 # Verbose logging.
 debug: false
+
+# Prometheus metrics. Off by default, unauthenticated when on. See "Operating".
+metrics:
+  enabled: false
 ```
 
 The binary also falls back to your own kubeconfig when it is not running in a
@@ -330,9 +334,21 @@ A controller, so: `/healthz` and `/readyz` on `:8081` by default, tunable under
 `probes`. Readiness means the manager is running, not that this replica holds the
 lease, so a standby stays Ready.
 
-Metrics are **not** served. Enabling them would mean either an unauthenticated
-port or pulling in the API server authn/authz stack, and there is nothing here
-worth either yet.
+Metrics are off by default, under `metrics`, and **unauthenticated** when on, so
+put a NetworkPolicy in front of the port. Four series, all counts of this
+instance's own decisions:
+
+| Metric | |
+|---|---|
+| `..._conflicts_total{reason}` | registrations refused, and why |
+| `..._adoptions_total` | orphaned `Secret`s adopted by a matching namespace |
+| `..._registrations{state}` | registrations owned, `active` or `demoted` |
+| `..._unrouted_secrets` | owned `Secret`s no reconcile key can reach |
+
+`conflicts_total{reason="incumbent"}` is the one worth alerting on: a contested
+name stays contested until someone resolves it. *Which* cluster is in the log
+line, not the labels, so a tenant cannot mint series by naming a namespace.
+`metrics.service.enabled` adds a `Service`; no `ServiceMonitor` ships.
 
 `leaderElection` is off by default and needs `leases` and `events` in
 `targetNamespace`. The lease is named for `labelPrefix` and `managedBy`, not for

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var (
 	secretNamePattern string
 	secretKey         string
 	labelPrefix       string
+	demotedTTL        time.Duration
 
 	leaderElect            bool
 	leaderElectionID       string
@@ -127,6 +128,7 @@ func buildOptions(cmd *cobra.Command) (options, error) {
 		Providers:       providers,
 		LabelPrefix:     labelPrefix,
 		DryRun:          dryRun,
+		DemotedTTL:      demotedTTL,
 	}
 	if err := cfg.Validate(); err != nil {
 		return options{}, err
@@ -145,6 +147,15 @@ func buildOptions(cmd *cobra.Command) (options, error) {
 		// the real one waits.
 		warnings = append(warnings, "--dry-run disables leader election")
 		elect = false
+	}
+
+	if demotedTTL > 0 && demotedTTL < interval {
+		// A demoted registration is only revisited when its namespace is
+		// requeued, so nothing can expire faster than the interval and a smaller
+		// TTL reads as a promise the loop cannot keep.
+		warnings = append(warnings, fmt.Sprintf(
+			"--demoted-ttl %s is shorter than --interval %s, so expiry cannot happen sooner than %s",
+			demotedTTL, interval, interval))
 	}
 
 	return options{
@@ -292,4 +303,8 @@ func registerFlags(f *pflag.FlagSet) {
 	// unauthenticated port on every install that never asked for one.
 	f.StringVar(&metricsBindAddress, "metrics-bind-address", "0",
 		`address serving Prometheus metrics; "0" disables it, which is the default`)
+	// Off by default. Demotion is the reversible half of removal, so putting a
+	// clock on it also puts a clock on how long a mistaken rename can be undone.
+	f.DurationVar(&demotedTTL, "demoted-ttl", 0,
+		"delete a demoted registration once it has been superseded this long; 0 keeps it indefinitely")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ var (
 	leaderElect            bool
 	leaderElectionID       string
 	healthProbeBindAddress string
+	metricsBindAddress     string
 )
 
 // resolveProviders turns the flags into the provider list, honouring the
@@ -153,6 +154,7 @@ func buildOptions(cmd *cobra.Command) (options, error) {
 			LeaderElection:         elect,
 			LeaderElectionID:       leaderElectionID,
 			HealthProbeBindAddress: healthProbeBindAddress,
+			MetricsBindAddress:     metricsBindAddress,
 		},
 		warnings: warnings,
 	}, nil
@@ -285,4 +287,9 @@ func registerFlags(f *pflag.FlagSet) {
 		"name of the Lease used for leader election, within --target-namespace")
 	f.StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081",
 		"address serving /healthz and /readyz; empty disables it")
+	// "0", not "": controller-runtime reads an empty metrics address as ":8080"
+	// rather than as "off", so defaulting to empty here would open an
+	// unauthenticated port on every install that never asked for one.
+	f.StringVar(&metricsBindAddress, "metrics-bind-address", "0",
+		`address serving Prometheus metrics; "0" disables it, which is the default`)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,6 +136,20 @@ func buildOptions(cmd *cobra.Command) (options, error) {
 
 	var warnings []string
 
+	// Derived unless it was set, so an instance deployed from a plain manifest
+	// takes the same lease as a chart-deployed one with identical configuration.
+	// The chart has always derived it; the binary defaulted to a constant, so the
+	// two would not contend and both would reconcile.
+	//
+	// Gated on Changed rather than emptiness, matching resolveProviders: an
+	// explicit empty value is a mistake worth reporting, not a request to derive.
+	lease := leaderElectionID
+	if !cmd.Flags().Changed("leader-election-id") {
+		lease = registrar.LeaderElectionID(labelPrefix, managedByValue)
+	} else if lease == "" {
+		return options{}, fmt.Errorf("--leader-election-id must not be empty; omit it to derive one")
+	}
+
 	// A local, deliberately NOT the package variable. Assigning to `leaderElect`
 	// here mutated global state from inside a request path: harmless in a process
 	// that runs this once, but in a test binary the value leaks into every case
@@ -163,7 +177,7 @@ func buildOptions(cmd *cobra.Command) (options, error) {
 		ctrl: registrar.ControllerOptions{
 			Interval:               interval,
 			LeaderElection:         elect,
-			LeaderElectionID:       leaderElectionID,
+			LeaderElectionID:       lease,
 			HealthProbeBindAddress: healthProbeBindAddress,
 			MetricsBindAddress:     metricsBindAddress,
 		},
@@ -294,8 +308,9 @@ func registerFlags(f *pflag.FlagSet) {
 	// collide, NOT from the release name: ownership is established purely by
 	// label-prefix and managed-by, so instances differing only in release name
 	// contend for the same Secrets and must contend for the same lease.
-	f.StringVar(&leaderElectionID, "leader-election-id", "argocd-cluster-registrar",
-		"name of the Lease used for leader election, within --target-namespace")
+	f.StringVar(&leaderElectionID, "leader-election-id", "",
+		"name of the Lease used for leader election, within --target-namespace; "+
+			"unset derives it from --label-prefix and --managed-by")
 	f.StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081",
 		"address serving /healthz and /readyz; empty disables it")
 	// "0", not "": controller-runtime reads an empty metrics address as ":8080"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,79 @@ func resolveProviders(cmd *cobra.Command) ([]registrar.Provider, error) {
 	return []registrar.Provider{p}, nil
 }
 
+// options is everything the flags decide, separated from the act of using them.
+//
+// Extracted because the two struct literals below are hand-written: a field left
+// off leaves the option at its zero value, and not every zero value is harmless.
+// Assembling them in a pure function is what makes "every flag reaches the option
+// it configures" a thing a test can assert without a cluster.
+//
+// Warnings are returned as DATA rather than logged in place. A function that logs
+// is a function whose warnings can only be tested by capturing a logger, which is
+// how a warning ends up silently never firing.
+type options struct {
+	cfg      registrar.Config
+	ctrl     registrar.ControllerOptions
+	warnings []string
+}
+
+// buildOptions maps the parsed flags onto the registrar's configuration.
+//
+// It talks to nothing. Everything below it in RunE -- building a client, taking a
+// lease, starting a manager -- needs a cluster and stays untestable; this is the
+// part that does not have to be.
+func buildOptions(cmd *cobra.Command) (options, error) {
+	if interval <= 0 {
+		// RequeueAfter: 0 means "do not requeue", so a Helm value of
+		// `interval: 0s` would leave every registration reconciled once and
+		// then never refreshed again -- silently, until a certificate
+		// rotation broke it days later.
+		return options{}, fmt.Errorf("--interval must be positive, got %s", interval)
+	}
+
+	providers, err := resolveProviders(cmd)
+	if err != nil {
+		return options{}, err
+	}
+
+	cfg := registrar.Config{
+		TargetNamespace: targetNamespace,
+		ManagedByValue:  managedByValue,
+		Providers:       providers,
+		LabelPrefix:     labelPrefix,
+		DryRun:          dryRun,
+	}
+	if err := cfg.Validate(); err != nil {
+		return options{}, err
+	}
+
+	var warnings []string
+
+	// A local, deliberately NOT the package variable. Assigning to `leaderElect`
+	// here mutated global state from inside a request path: harmless in a process
+	// that runs this once, but in a test binary the value leaks into every case
+	// that runs afterwards.
+	elect := leaderElect
+	if elect && dryRun {
+		// Same hazard as a second live instance, slower: a --dry-run process
+		// holding the lease is a registrar that reports what it would do while
+		// the real one waits.
+		warnings = append(warnings, "--dry-run disables leader election")
+		elect = false
+	}
+
+	return options{
+		cfg: cfg,
+		ctrl: registrar.ControllerOptions{
+			Interval:               interval,
+			LeaderElection:         elect,
+			LeaderElectionID:       leaderElectionID,
+			HealthProbeBindAddress: healthProbeBindAddress,
+		},
+		warnings: warnings,
+	}, nil
+}
+
 var rootCmd = &cobra.Command{
 	Use: "argocd-cluster-registrar",
 	// A runtime failure is not a usage error. Without these, any error out of
@@ -127,31 +200,17 @@ unclaimed name contested by several namespaces goes to the oldest.`,
 			AddSource: debug,
 		}))
 
-		if interval <= 0 {
-			// RequeueAfter: 0 means "do not requeue", so a Helm value of
-			// `interval: 0s` would leave every registration reconciled once and
-			// then never refreshed again -- silently, until a certificate
-			// rotation broke it days later.
-			return fmt.Errorf("--interval must be positive, got %s", interval)
-		}
-
-		providers, err := resolveProviders(cmd)
+		opts, err := buildOptions(cmd)
 		if err != nil {
 			return err
 		}
-
-		cfg := registrar.Config{
-			TargetNamespace: targetNamespace,
-			ManagedByValue:  managedByValue,
-			Providers:       providers,
-			LabelPrefix:     labelPrefix,
-			DryRun:          dryRun,
-		}
-		if err := cfg.Validate(); err != nil {
-			return err
+		// Emitted before the --once return below, deliberately: these describe the
+		// configuration, not the manager, so a pre-flight run must report them too.
+		for _, w := range opts.warnings {
+			log.Warn(w)
 		}
 
-		r, err := registrar.New(log, cfg)
+		r, err := registrar.New(log, opts.cfg)
 		if err != nil {
 			return err
 		}
@@ -163,8 +222,8 @@ unclaimed name contested by several namespaces goes to the oldest.`,
 		// default. This line is the only startup evidence of what the process is
 		// looking for, and logging `secretNamePattern` meant it always announced
 		// `k3k-*-kubeconfig` no matter what --provider was set to.
-		names := make([]string, 0, len(providers))
-		for _, p := range providers {
+		names := make([]string, 0, len(opts.cfg.Providers))
+		for _, p := range opts.cfg.Providers {
 			names = append(names, p.Name)
 		}
 		log.Info("resolved providers", slog.String("providers", strings.Join(names, ",")))
@@ -176,19 +235,7 @@ unclaimed name contested by several namespaces goes to the oldest.`,
 			return r.Reconcile(ctx)
 		}
 
-		if leaderElect && dryRun {
-			// Same hazard, slower: a --dry-run process holding the lease is a
-			// registrar that reports what it would do while the real one waits.
-			log.Warn("--dry-run disables leader election")
-			leaderElect = false
-		}
-
-		return r.Start(ctx, registrar.ControllerOptions{
-			Interval:               interval,
-			LeaderElection:         leaderElect,
-			LeaderElectionID:       leaderElectionID,
-			HealthProbeBindAddress: healthProbeBindAddress,
-		})
+		return r.Start(ctx, opts.ctrl)
 	},
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -213,6 +213,8 @@ func TestEveryFlagReachesTheOptionItConfigures(t *testing.T) {
 			func(o options) string { return o.ctrl.Interval.String() }},
 		{"--health-probe-bind-address=:9", ":9",
 			func(o options) string { return o.ctrl.HealthProbeBindAddress }},
+		{"--metrics-bind-address=:9090", ":9090",
+			func(o options) string { return o.ctrl.MetricsBindAddress }},
 		{"--leader-election-id=some-other-lease", "some-other-lease",
 			func(o options) string { return o.ctrl.LeaderElectionID }},
 		{"--leader-elect", "true",
@@ -275,5 +277,23 @@ func TestANonPositiveIntervalIsRejected(t *testing.T) {
 			t.Errorf("%s was accepted; every registration would be reconciled once "+
 				"and then never refreshed", arg)
 		}
+	}
+}
+
+// Metrics stay off unless asked for, and "off" is the string "0".
+//
+// Not the empty string: controller-runtime reads an empty bind address as
+// ":8080" rather than as "off", so defaulting to empty here would open an
+// unauthenticated port on every install that never mentioned metrics. The
+// manager normalises empty to "0" as well; both are wanted, because either
+// alone can be undone by a plausible edit to the other.
+func TestMetricsAreOffUnlessAskedFor(t *testing.T) {
+	opts, err := buildOptions(parseFlags(t))
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	if opts.ctrl.MetricsBindAddress != "0" {
+		t.Errorf("default metrics bind address = %q, want \"0\"; an empty value "+
+			"serves :8080 unauthenticated", opts.ctrl.MetricsBindAddress)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -177,6 +178,102 @@ func TestResolvedProvidersPassValidation(t *testing.T) {
 		}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("%v produced a config that fails validation: %v", args, err)
+		}
+	}
+}
+
+// Every flag must reach the option it configures.
+//
+// The two struct literals in buildOptions are hand-written, so a field left off
+// leaves the option at its zero value and nothing complains. That is not a
+// theoretical worry: leaving LeaderElection unset merely disables a feature,
+// while leaving a bind address unset hands controller-runtime an empty string,
+// which it reads as "serve on the default port" rather than as "off".
+//
+// Each flag is parsed ALONE. Setting several at once would hide the one
+// interaction that exists (--dry-run de-escalating --leader-elect), and a case
+// asserting `LeaderElection == true` would then fail for a reason that has
+// nothing to do with wiring.
+//
+// The `want != base` assertion is what stops this passing vacuously: with
+// --target-namespace=argocd, a field that is never assigned still reads "argocd"
+// and the test would prove nothing.
+func TestEveryFlagReachesTheOptionItConfigures(t *testing.T) {
+	base, err := buildOptions(parseFlags(t))
+	if err != nil {
+		t.Fatalf("defaults do not build: %v", err)
+	}
+
+	for _, tc := range []struct {
+		arg  string
+		want string
+		got  func(options) string
+	}{
+		{"--interval=90s", "1m30s",
+			func(o options) string { return o.ctrl.Interval.String() }},
+		{"--health-probe-bind-address=:9", ":9",
+			func(o options) string { return o.ctrl.HealthProbeBindAddress }},
+		{"--leader-election-id=some-other-lease", "some-other-lease",
+			func(o options) string { return o.ctrl.LeaderElectionID }},
+		{"--leader-elect", "true",
+			func(o options) string { return fmt.Sprint(o.ctrl.LeaderElection) }},
+		{"--target-namespace=somewhere-else", "somewhere-else",
+			func(o options) string { return o.cfg.TargetNamespace }},
+		{"--managed-by=some-other-value", "some-other-value",
+			func(o options) string { return o.cfg.ManagedByValue }},
+		{"--label-prefix=example.com/", "example.com/",
+			func(o options) string { return o.cfg.LabelPrefix }},
+		{"--dry-run", "true",
+			func(o options) string { return fmt.Sprint(o.cfg.DryRun) }},
+	} {
+		t.Run(tc.arg, func(t *testing.T) {
+			if d := tc.got(base); d == tc.want {
+				t.Fatalf("the test value %q equals the flag's default, so this case "+
+					"would pass even if the field were never assigned", tc.want)
+			}
+			opts, err := buildOptions(parseFlags(t, tc.arg))
+			if err != nil {
+				t.Fatalf("buildOptions: %v", err)
+			}
+			if got := tc.got(opts); got != tc.want {
+				t.Errorf("%s produced %q, want %q; the flag does not reach its option",
+					tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+// --dry-run must stand a --leader-elect down, and must not write that decision
+// back into the flag variable.
+//
+// The flags bind to package-level variables. Assigning to one from inside the
+// run path used to leave it mutated for the rest of the process, which in a test
+// binary means every later case inherits it.
+func TestDryRunDeEscalatesLeaderElectionWithoutMutatingTheFlag(t *testing.T) {
+	opts, err := buildOptions(parseFlags(t, "--dry-run", "--leader-elect"))
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	if opts.ctrl.LeaderElection {
+		t.Error("a --dry-run process would hold the lease while the real registrar waited")
+	}
+	if !leaderElect {
+		t.Error("the --leader-elect flag variable was mutated; that state leaks into " +
+			"every later caller in the process")
+	}
+	if len(opts.warnings) != 1 || !strings.Contains(opts.warnings[0], "leader election") {
+		t.Errorf("warnings = %q, want one mentioning leader election", opts.warnings)
+	}
+}
+
+// A zero or negative interval means RequeueAfter: 0, which controller-runtime
+// reads as "never come back". Rejecting it is the difference between a loud
+// startup failure and registrations that silently stop refreshing.
+func TestANonPositiveIntervalIsRejected(t *testing.T) {
+	for _, arg := range []string{"--interval=0s", "--interval=-1s"} {
+		if _, err := buildOptions(parseFlags(t, arg)); err == nil {
+			t.Errorf("%s was accepted; every registration would be reconciled once "+
+				"and then never refreshed", arg)
 		}
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -297,3 +297,38 @@ func TestMetricsAreOffUnlessAskedFor(t *testing.T) {
 			"serves :8080 unauthenticated", opts.ctrl.MetricsBindAddress)
 	}
 }
+
+// An unset --leader-election-id must derive the same lease the chart does.
+//
+// The binary used to default it to a constant while the chart derived it from
+// labelPrefix and managedBy. So an instance deployed from a plain manifest and a
+// chart-deployed one with identical configuration, contending for the same
+// cluster Secrets, held different leases and both reconciled: precisely the state
+// leader election exists to prevent, reached by not using the chart.
+func TestAnUnsetLeaseNameIsDerivedNotConstant(t *testing.T) {
+	opts, err := buildOptions(parseFlags(t))
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	want := registrar.LeaderElectionID(registrar.DefaultLabelPrefix, "cluster-registrar")
+	if opts.ctrl.LeaderElectionID != want {
+		t.Errorf("lease = %q, want %q", opts.ctrl.LeaderElectionID, want)
+	}
+
+	// ...and it must follow the values it is derived from, or two installs that
+	// never meet are serialised against each other.
+	other, err := buildOptions(parseFlags(t, "--managed-by=something-else"))
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+	if other.ctrl.LeaderElectionID == opts.ctrl.LeaderElectionID {
+		t.Error("changing --managed-by did not change the derived lease")
+	}
+}
+
+// An explicit empty value is a mistake, not a request to derive.
+func TestAnExplicitlyEmptyLeaseNameIsRejected(t *testing.T) {
+	if _, err := buildOptions(parseFlags(t, "--leader-election-id=")); err == nil {
+		t.Error("an empty lease name was accepted; the manager would fail to start")
+	}
+}

--- a/deploy/charts/argocd-cluster-registrar/Chart.yaml
+++ b/deploy/charts/argocd-cluster-registrar/Chart.yaml
@@ -3,8 +3,8 @@ name: argocd-cluster-registrar
 description: Kubernetes controller that registers the clusters you run inside your cluster with ArgoCD, and removes them again when they are deleted
 
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 
 home: https://github.com/pcanilho/argocd-cluster-registrar
 sources:

--- a/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
+++ b/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
@@ -17,6 +17,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- /* Both bind addresses are turned into a containerPort by stripping the colon,
+         so "0.0.0.0:8081" silently renders containerPort: 0 and "8081" hands the
+         binary an address it cannot listen on. Fail here, naming the key. */}}
+  {{- if and .Values.probes.enabled (not (regexMatch "^:[0-9]+$" .Values.probes.bindAddress)) }}
+  {{- fail (printf "probes.bindAddress must be of the form \":PORT\", got %q" .Values.probes.bindAddress) }}
+  {{- end }}
+  {{- if and .Values.metrics.enabled (not (regexMatch "^:[0-9]+$" .Values.metrics.bindAddress)) }}
+  {{- fail (printf "metrics.bindAddress must be of the form \":PORT\", got %q" .Values.metrics.bindAddress) }}
+  {{- end }}
   {{- if and (gt (int .Values.replicaCount) 1) (not .Values.leaderElection.enabled) }}
   {{- fail "replicaCount > 1 requires leaderElection.enabled. Two active instances sharing a managedBy value rewrite each other's provider label on every reconcile." }}
   {{- end }}

--- a/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
+++ b/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             - "--secret-key={{ required "secretKey is required when secretNamePattern is set" .Values.secretKey }}"
             {{- end }}
             - "--interval={{ .Values.interval }}"
+            {{- /* Always emitted: `0s` is a truthy string but `0` is a falsy int, so
+                   a conditional would render opposite results for the same intent. */}}
+            - "--demoted-ttl={{ .Values.demotedTTL | default "0s" }}"
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect
             - "--leader-election-id={{ include "app.leaderElectionID" . }}"

--- a/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
+++ b/deploy/charts/argocd-cluster-registrar/templates/deployment.yaml
@@ -90,17 +90,31 @@ spec:
             {{- else }}
             - "--health-probe-bind-address="
             {{- end }}
+            {{- /* No else branch, unlike probes above: an empty --metrics-bind-address
+                   means ":8080", not "off". Leave it unset and the binary defaults to "0". */}}
+            {{- if .Values.metrics.enabled }}
+            - "--metrics-bind-address={{ .Values.metrics.bindAddress }}"
+            {{- end }}
             {{- if .Values.dryRun }}
             - --dry-run
             {{- end }}
             {{- if .Values.debug }}
             - --debug
             {{- end }}
-          {{- if .Values.probes.enabled }}
+          {{- if or .Values.probes.enabled .Values.metrics.enabled }}
           ports:
+            {{- if .Values.probes.enabled }}
             - name: probes
               containerPort: {{ .Values.probes.bindAddress | trimPrefix ":" | int }}
               protocol: TCP
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.bindAddress | trimPrefix ":" | int }}
+              protocol: TCP
+            {{- end }}
+          {{- end }}
+          {{- if .Values.probes.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/charts/argocd-cluster-registrar/templates/service.yaml
+++ b/deploy/charts/argocd-cluster-registrar/templates/service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.metrics.enabled .Values.metrics.service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-metrics
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- $annotations := merge (dict) (.Values.metrics.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      # By NAME, so that changing metrics.bindAddress cannot leave the Service
+      # pointing at a port nothing listens on.
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/deploy/charts/argocd-cluster-registrar/values.yaml
+++ b/deploy/charts/argocd-cluster-registrar/values.yaml
@@ -103,6 +103,29 @@ probes:
     initialDelaySeconds: 5
     periodSeconds: 10
 
+# Prometheus metrics. Four series, all counts of this instance's own decisions:
+# registrations refused and why, orphans adopted, registrations owned by state,
+# and owned Secrets that no reconcile key can reach.
+#
+# OFF by default, and served UNAUTHENTICATED when on. Protecting the endpoint
+# means controller-runtime's authn/authz filter, which pulls in k8s.io/apiserver
+# and needs `tokenreviews`/`subjectaccessreviews` RBAC. Nothing published here
+# carries a cluster name, a namespace or any credential, so a NetworkPolicy is
+# the proportionate control. Which cluster is contested stays in the logs, where
+# it does not become unbounded monitoring cardinality anyone able to label a
+# namespace could mint.
+#
+# No ServiceMonitor ships. It needs a CRD that `helm template` cannot check for,
+# so it could not be proven correct in CI. Point your scrape config at the
+# Service, or add a ServiceMonitor of your own.
+metrics:
+  enabled: false
+  bindAddress: ":8080"
+  service:
+    enabled: false
+    port: 8080
+    annotations: {}
+
 # One is the right number. There is no work to parallelise and no HA requirement;
 # a brief outage of this controller costs nothing, since it converges on restart.
 # More than one requires leaderElection.enabled, or they would rewrite each

--- a/deploy/charts/argocd-cluster-registrar/values.yaml
+++ b/deploy/charts/argocd-cluster-registrar/values.yaml
@@ -25,6 +25,12 @@ managedBy: cluster-registrar
 # patterns legitimately overlap: `capi` matches `*-kubeconfig`, which includes
 # k3k's Secret. Correctness comes from the key, not the name.
 #
+# `secretKeys` is ordered too. Every declared key present on a Secret is tried in
+# turn and the first that parses wins, so a half-written or otherwise unusable key
+# falls through to the next rather than stranding the namespace. Put the key you
+# prefer first: Kamaji's `admin.conf` and `admin.svc` both normally parse, so the
+# declared order is what decides between them.
+#
 # Built-in presets: k3k, vcluster, kamaji, capi. A custom shape can be spelled
 # out in full instead:
 #

--- a/deploy/charts/argocd-cluster-registrar/values.yaml
+++ b/deploy/charts/argocd-cluster-registrar/values.yaml
@@ -75,6 +75,16 @@ secretKey: ""
 # ArgoCD is holding the old one. Lowering it no longer speeds anything else up.
 interval: 60s
 
+# Delete a demoted registration once it has been superseded this long. 0 keeps
+# it indefinitely, which is the behaviour before 0.5.0.
+#
+# A rename hides the old registration from ArgoCD rather than deleting it, so
+# reverting the rename restores it. The debris accumulates until its namespace
+# is deleted; this bounds that, at the cost of bounding how long a revert works.
+# Expiry only happens while the source namespace is alive and registered under
+# another name, and no sooner than `interval`.
+demotedTTL: 0s
+
 # Log intended changes without writing. Worth using when first pointing this at
 # an existing cluster, to confirm the GC selector matches only what you expect.
 dryRun: false

--- a/deploy/charts/argocd-cluster-registrar/values.yaml
+++ b/deploy/charts/argocd-cluster-registrar/values.yaml
@@ -105,6 +105,8 @@ leaderElection:
 # replica is the leader, so a standby stays Ready.
 probes:
   enabled: true
+  # ":PORT" only. The container port is derived from this by stripping the colon,
+  # so "0.0.0.0:8081" would render containerPort 0. The chart rejects anything else.
   bindAddress: ":8081"
   liveness:
     initialDelaySeconds: 15
@@ -130,6 +132,7 @@ probes:
 # Service, or add a ServiceMonitor of your own.
 metrics:
   enabled: false
+  # ":PORT" only, as with probes.bindAddress above.
   bindAddress: ":8080"
   service:
     enabled: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,55 @@
+# Architecture
+
+Notes for anyone changing this. Two decisions look like oversights and are not;
+both have been tried the other way.
+
+## Only namespaces are watched
+
+Not the provisioner-written kubeconfig `Secret`s, even though watching them would
+spot a credential rotation sooner.
+
+k3k regenerates the child's keypair on *every one of its own reconciles*
+(`ensureKubeconfigSecret` calls `generateKey()` unconditionally), so that `Secret`
+changes far more often than the credential meaningfully does. The reconcile
+interval is what keeps that from becoming one write per k3k reconcile against a
+credential-bearing `Secret` in the ArgoCD namespace, each of which invalidates
+ArgoCD's own cluster cache. In other words the interval is a coalescing rate
+limiter, not a polling fallback.
+
+Such a watch could not be narrowed either: the provisioner owns that `Secret`, so
+it carries none of our labels. That is the same reason discovery is driven by the
+namespace in the first place.
+
+It would also hide a bug rather than expose one. A missing `RequeueAfter` would
+be invisible on k3k, which writes constantly, while still breaking the three
+quiet providers.
+
+## Nothing is read through the controller's cache
+
+Every read goes through `kubernetes.Interface`, direct.
+
+The namespace existence proof in particular must not be cached. A label-filtered
+cache reports an object that stops matching the selector as a synthetic deletion,
+so a cached `NotFound` cannot tell a deleted namespace from one that merely lost
+a label. Deregistering on the second would be catastrophic, and it is exactly
+what `ReconcileOne` re-checks the ownership label to prevent.
+
+The cache is configured with `ReaderFailOnMissingInformer`, so a cached read of
+anything unconfigured is an error rather than a cluster-wide informer started
+silently in the background. No `Secret` is ever held in it.
+
+## Deletion requires positive proof
+
+A registration is removed only on evidence that its source is gone, never on
+absence from a desired set. There are three admissible proofs, and no others:
+
+- the source namespace returns a definite `NotFound`;
+- the namespace name is now held by a *different* object, proven by a recorded
+  `source-namespace-uid` that does not match (`collectStaleUID`);
+- a demoted registration has outlived `demotedTTL` (`deleteExpired`).
+
+A transient API failure proves nothing, and every path that cannot evaluate a
+namespace skips collection for it entirely rather than concluding anything.
+
+Renaming is not a deletion: the old registration is *demoted*, which is
+reversible, rather than deleted. See the README for what that means operationally.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/go-logr/logr v1.4.4
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0
 	github.com/spf13/pflag v1.0.9
 	k8s.io/api v0.35.0
@@ -34,12 +35,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/pcanilho/argocd-cluster-registrar
 
-go 1.26.5
+go 1.26
+
+toolchain go1.26.5
 
 require (
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/registrar/controller.go
+++ b/internal/registrar/controller.go
@@ -59,9 +59,14 @@ type ControllerOptions struct {
 	// HealthProbeBindAddress serves /healthz and /readyz. Empty disables it.
 	HealthProbeBindAddress string
 
-	// RestConfig overrides the ambient cluster connection. Nil, the normal case,
+	// RestConfig overrides the connection the MANAGER uses. Nil, the normal case,
 	// means in-cluster config or the caller's own kubeconfig. Set by tests that
 	// drive a real manager against envtest.
+	//
+	// It does NOT redirect the clientset. A Registrar built by New already holds
+	// one against the ambient cluster, so setting this on that Registrar points
+	// the watch at one cluster while every read and write goes to another. Pair it
+	// with NewWithClient and a client built from the same config.
 	RestConfig *rest.Config
 
 	// MetricsBindAddress serves Prometheus metrics. "0" disables it, and that is

--- a/internal/registrar/controller.go
+++ b/internal/registrar/controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +58,11 @@ type ControllerOptions struct {
 
 	// HealthProbeBindAddress serves /healthz and /readyz. Empty disables it.
 	HealthProbeBindAddress string
+
+	// RestConfig overrides the ambient cluster connection. Nil, the normal case,
+	// means in-cluster config or the caller's own kubeconfig. Set by tests that
+	// drive a real manager against envtest.
+	RestConfig *rest.Config
 
 	// MetricsBindAddress serves Prometheus metrics. "0" disables it, and that is
 	// the default.
@@ -126,8 +132,7 @@ func newScheme() (*runtime.Scheme, error) {
 }
 
 // managerOptions is separate so the options with dangerous defaults can be
-// asserted in a test. Start itself cannot be: it builds a client against the
-// ambient cluster.
+// asserted without standing up a manager at all.
 func managerOptions(cfg Config, opts ControllerOptions, scheme *runtime.Scheme) ctrl.Options {
 	// Empty means "off" here, even though controller-runtime reads it as ":8080".
 	// Without this, a ControllerOptions that simply does not mention metrics --
@@ -205,9 +210,15 @@ func (r *Registrar) Start(ctx context.Context, opts ControllerOptions) error {
 	if err != nil {
 		return err
 	}
-	base, err := BaseRestConfig()
-	if err != nil {
-		return err
+	// Injected config wins, mirroring the client seam below. Without it Start can
+	// only ever be run against the ambient cluster, which is what kept the manager
+	// wiring out of reach of the test suite.
+	base := opts.RestConfig
+	if base == nil {
+		var err error
+		if base, err = BaseRestConfig(); err != nil {
+			return err
+		}
 	}
 
 	// controller-runtime logs through logr. Without this it prints one warning to

--- a/internal/registrar/controller.go
+++ b/internal/registrar/controller.go
@@ -38,6 +38,9 @@ const auditKey = ""
 // needs to be large enough that a normal fleet does not serialise on it.
 const seedBuffer = 256
 
+// metricsDisabled is the value controller-runtime treats as "do not serve".
+const metricsDisabled = "0"
+
 // ControllerOptions configures the manager. Everything here is operational; what
 // the registrar actually does is in Config.
 type ControllerOptions struct {
@@ -54,6 +57,16 @@ type ControllerOptions struct {
 
 	// HealthProbeBindAddress serves /healthz and /readyz. Empty disables it.
 	HealthProbeBindAddress string
+
+	// MetricsBindAddress serves Prometheus metrics. "0" disables it, and that is
+	// the default.
+	//
+	// Note the asymmetry with HealthProbeBindAddress above, which is not an
+	// oversight and must not be tidied away: controller-runtime reads an EMPTY
+	// metrics address as ":8080" rather than as "off", so the two fields disable
+	// on different values. managerOptions normalises empty to "0" so that a
+	// zero-valued ControllerOptions cannot open an unauthenticated port.
+	MetricsBindAddress string
 }
 
 // Reconciler adapts a Registrar to controller-runtime.
@@ -116,6 +129,17 @@ func newScheme() (*runtime.Scheme, error) {
 // asserted in a test. Start itself cannot be: it builds a client against the
 // ambient cluster.
 func managerOptions(cfg Config, opts ControllerOptions, scheme *runtime.Scheme) ctrl.Options {
+	// Empty means "off" here, even though controller-runtime reads it as ":8080".
+	// Without this, a ControllerOptions that simply does not mention metrics --
+	// a zero value, a caller that forgot the field, a test -- would serve an
+	// unauthenticated endpoint on a port nobody chose. The flag default is "0" as
+	// well; both are wanted, because either alone can be undone by a plausible
+	// edit to the other.
+	metricsBind := opts.MetricsBindAddress
+	if metricsBind == "" {
+		metricsBind = metricsDisabled
+	}
+
 	return ctrl.Options{
 		Scheme: scheme,
 		Cache: cache.Options{
@@ -138,8 +162,12 @@ func managerOptions(cfg Config, opts ControllerOptions, scheme *runtime.Scheme) 
 		Client: client.Options{
 			Cache: &client.CacheOptions{DisableFor: []client.Object{&coreV1.Secret{}}},
 		},
-		// "0" disables. An empty string would bind :8080 unauthenticated.
-		Metrics:                       metricsserver.Options{BindAddress: "0"},
+		// Served unauthenticated when enabled, deliberately. Protecting it means
+		// controller-runtime's authn/authz filter, which drags in k8s.io/apiserver
+		// and needs tokenreviews/subjectaccessreviews RBAC; the four series here
+		// are counts of the instance's own decisions and carry no cluster
+		// identity, so a NetworkPolicy is the proportionate control.
+		Metrics:                       metricsserver.Options{BindAddress: metricsBind},
 		HealthProbeBindAddress:        opts.HealthProbeBindAddress,
 		LeaderElection:                opts.LeaderElection,
 		LeaderElectionID:              opts.LeaderElectionID,

--- a/internal/registrar/controller_test.go
+++ b/internal/registrar/controller_test.go
@@ -285,9 +285,9 @@ func TestDemotionSurvivesAClusterNameTooLongForALabelValue(t *testing.T) {
 	}
 }
 
-// The manager wiring has no other coverage: Start builds a real client and talks
-// to the ambient cluster, so it cannot be driven from a test. These are the
-// options whose defaults are actively dangerous.
+// These are the options whose defaults are actively dangerous, asserted here
+// rather than through a running manager because the failure mode is silent: the
+// wrong value works fine and merely exposes something it should not.
 func TestManagerOptionsPinTheDangerousDefaults(t *testing.T) {
 	scheme, err := newScheme()
 	if err != nil {

--- a/internal/registrar/controller_test.go
+++ b/internal/registrar/controller_test.go
@@ -302,9 +302,13 @@ func TestManagerOptionsPinTheDangerousDefaults(t *testing.T) {
 		t.Error("a cached read of an unconfigured resource would silently start a " +
 			"cluster-wide informer instead of failing")
 	}
-	if opts.Metrics.BindAddress != "0" {
-		t.Errorf("metrics BindAddress = %q; anything but \"0\" serves :8080 unauthenticated",
-			opts.Metrics.BindAddress)
+	// An UNSET metrics address, which is what a zero-valued ControllerOptions and
+	// any caller that forgets the field both produce. controller-runtime reads
+	// empty as ":8080", so without the normalisation this is how an installation
+	// that never asked for metrics ends up serving them unauthenticated.
+	if opts.Metrics.BindAddress != metricsDisabled {
+		t.Errorf("metrics BindAddress = %q for an unset option; anything but %q "+
+			"serves :8080 unauthenticated", opts.Metrics.BindAddress, metricsDisabled)
 	}
 	if opts.Client.Cache == nil || len(opts.Client.Cache.DisableFor) == 0 {
 		t.Fatal("Secrets are not excluded from the cached client")
@@ -332,5 +336,28 @@ func TestManagerOptionsPinTheDangerousDefaults(t *testing.T) {
 		t.Errorf("LeaderElectionNamespace = %q, want %q; unset means the pod's own "+
 			"namespace, which is not where two colliding releases meet",
 			opts.LeaderElectionNamespace, testTargetNS)
+	}
+}
+
+// Metrics must still be servable when asked for, or the normalisation above
+// could be "fixed" by hardcoding the disabled value and nothing would notice.
+//
+// The port is one that appears nowhere else in this package: passing through
+// HealthProbeBindAddress by mistake would otherwise satisfy an assertion that
+// only checked the value was not "0".
+func TestMetricsBindAddressIsPassedThroughWhenSet(t *testing.T) {
+	scheme, err := newScheme()
+	if err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	opts := managerOptions(testConfig(), ControllerOptions{
+		Interval:               time.Minute,
+		HealthProbeBindAddress: ":8081",
+		MetricsBindAddress:     ":9090",
+	}, scheme)
+
+	if opts.Metrics.BindAddress != ":9090" {
+		t.Errorf("metrics BindAddress = %q, want :9090; the option does not reach the manager",
+			opts.Metrics.BindAddress)
 	}
 }

--- a/internal/registrar/envtest_test.go
+++ b/internal/registrar/envtest_test.go
@@ -1,0 +1,109 @@
+package registrar
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// startEnvtest brings up a real apiserver, or skips.
+//
+// No build tag. A tagged test that CI never runs rots quietly and gets deleted
+// six months later; this one at least compiles on every `go build`. The cost is
+// that a skip is indistinguishable from a pass, so CI asserts the case actually
+// RAN rather than trusting the exit code.
+func startEnvtest(t *testing.T) *rest.Config {
+	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS is unset; run `setup-envtest use` to enable this")
+	}
+	env := &envtest.Environment{}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := env.Stop(); err != nil {
+			t.Logf("stop envtest: %v", err)
+		}
+	})
+	return cfg
+}
+
+// A registration whose source namespace vanished while the process was down is
+// collected on startup.
+//
+// This is the one thing neither the kind job nor the managerOptions assertions
+// cover. Registration and deletion are driven by the namespace watch, but a
+// namespace deleted while nothing was running produces no event to catch up on:
+// the only thing that finds it is the startup seeder, which reconstructs the key
+// set from the source-namespace label of every owned Secret. Delete that
+// runnable and everything else still works, while an orphaned registration
+// survives forever with no symptom at all.
+func TestAStrandedRegistrationIsCollectedOnStartup(t *testing.T) {
+	base := startEnvtest(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := ClientFor(base)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.CoreV1().Namespaces().Create(ctx,
+		&coreV1.Namespace{ObjectMeta: metaV1.ObjectMeta{Name: testTargetNS}},
+		metaV1.CreateOptions{}); err != nil {
+		t.Fatalf("create %s: %v", testTargetNS, err)
+	}
+
+	// Records a source namespace that has NEVER existed. If it existed at any
+	// point while the manager ran, the watch would deliver its deletion and the
+	// seeder would not be what collected this.
+	orphan := registeredSecret("ghost", "k3k-ghost")
+	if _, err := client.CoreV1().Secrets(testTargetNS).Create(ctx, orphan, metaV1.CreateOptions{}); err != nil {
+		t.Fatalf("create orphan: %v", err)
+	}
+
+	r := NewWithClient(slog.New(slog.NewTextHandler(io.Discard, nil)), testConfig(), client)
+
+	// Buffered, and selected on below: Start blocks, so an immediate failure would
+	// otherwise be indistinguishable from a slow start until the deadline expires
+	// and reports the wrong thing.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Start(ctx, ControllerOptions{
+			Interval:   time.Second,
+			RestConfig: base,
+			// Empty, so the test binds no ports and parallel runs cannot collide.
+			HealthProbeBindAddress: "",
+		})
+	}()
+
+	deadline := time.After(60 * time.Second)
+	for {
+		select {
+		case err := <-errCh:
+			t.Fatalf("manager exited before collecting the orphan: %v", err)
+		case <-deadline:
+			t.Fatal("the stranded registration was never collected; the startup seeder " +
+				"is the only thing that would have found it")
+		case <-time.After(time.Second):
+			_, err := client.CoreV1().Secrets(testTargetNS).
+				Get(ctx, orphan.Name, metaV1.GetOptions{})
+			if apiErrors.IsNotFound(err) {
+				return
+			}
+			if err != nil {
+				t.Fatalf("get orphan: %v", err)
+			}
+		}
+	}
+}

--- a/internal/registrar/kubeconfig.go
+++ b/internal/registrar/kubeconfig.go
@@ -18,6 +18,10 @@ type kubeconfigCluster struct {
 	CertificateAuthorityData string `yaml:"certificate-authority-data"`
 	CertificateAuthority     string `yaml:"certificate-authority"`
 	InsecureSkipTLSVerify    bool   `yaml:"insecure-skip-tls-verify"`
+	// TLSServerName is what the certificate must be valid for when it does not
+	// match the address in Server. Dropping it produced a registration with the
+	// right CA and the right credentials that still failed hostname verification.
+	TLSServerName string `yaml:"tls-server-name"`
 }
 
 type kubeconfigUser struct {
@@ -168,8 +172,9 @@ func parseKubeconfig(raw []byte) (server string, config string, err error) {
 
 	cfg := argoClusterConfig{
 		TLSClientConfig: argoTLSClientConfig{
-			Insecure: c.InsecureSkipTLSVerify,
-			CaData:   c.CertificateAuthorityData,
+			Insecure:   c.InsecureSkipTLSVerify,
+			CaData:     c.CertificateAuthorityData,
+			ServerName: c.TLSServerName,
 		},
 	}
 

--- a/internal/registrar/kubeconfig_test.go
+++ b/internal/registrar/kubeconfig_test.go
@@ -83,6 +83,30 @@ contexts:
 current-context: kubernetes-admin@tenant-00
 `
 
+// Kamaji's OTHER key, `admin.svc`, written alongside admin.conf when the control
+// plane advertises an in-cluster Service address. Deliberately a different server
+// from kamajiKubeconfig: a fallthrough test whose two candidates resolve to the
+// same address passes whichever one was used, which proves nothing.
+const kamajiSvcKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: tenant-00
+  cluster:
+    server: https://tenant-00.kamaji.svc:6443
+    certificate-authority-data: Y2FkYXRh
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data: Y2VydGRhdGE=
+    client-key-data: a2V5ZGF0YQ==
+contexts:
+- name: kubernetes-admin@tenant-00
+  context:
+    cluster: tenant-00
+    user: kubernetes-admin
+current-context: kubernetes-admin@tenant-00
+`
+
 // The Cluster API contract shape: Secret `<cluster>-kubeconfig`, key `value`.
 // CAPI emits multiple entries with an explicit current-context, which is exactly
 // the case resolve() refuses to guess about.

--- a/internal/registrar/metrics.go
+++ b/internal/registrar/metrics.go
@@ -1,0 +1,88 @@
+package registrar
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metrics for the outcomes a log line alone cannot be alerted on.
+//
+// WHY THESE ARE PACKAGE-LEVEL rather than a field on Registrar, which is how the
+// logger is threaded: controller-runtime's Registry is a process global and
+// MustRegister PANICS on a duplicate. One Registrar per process makes an instance
+// field buy nothing, and the test binary builds dozens of them by struct literal,
+// so registering in a constructor would panic on the second one and a field left
+// nil would panic in production on whichever path forgot to guard it.
+//
+// WHY THE LABELS ARE ALL CONSTANTS. Every label value below comes from a closed
+// set fixed at compile time. Nothing here is a cluster name, a namespace or
+// anything else read off an object a tenant can create. That is deliberate on the
+// conflict path especially, which is the one path that exists because somebody
+// may be acting in bad faith: labelling by cluster name would let anyone able to
+// label a namespace mint unbounded series in the monitoring system.
+//
+// WHY THERE IS NO PER-CONFLICT GAUGE. A gauge keyed on the contested name and the
+// two namespaces would answer "which cluster is contested right now", and it is
+// tempting. It cannot be cleared. When the losing claimant's namespace is
+// deleted, ReconcileOne takes the NotFound branch and never reaches apply, so
+// nothing is left to zero the series and it alerts forever on a conflict that no
+// longer exists. The identity lives in the log line, which carries the cluster,
+// both namespaces and the reason. The metric's job is to make that line worth
+// looking for.
+var (
+	conflictsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "argocd_cluster_registrar_conflicts_total",
+		Help: "Registrations refused because the cluster name was already spoken for, by reason.",
+	}, []string{"reason"})
+
+	adoptionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "argocd_cluster_registrar_adoptions_total",
+		Help: "Owned cluster Secrets recording no source namespace that were adopted by a matching namespace.",
+	})
+
+	// registrations is a gauge rather than a counter because the question is "are
+	// demoted registrations piling up", which is a level and not a rate. It is set
+	// from the audit pass, which already lists every owned Secret, so it costs no
+	// extra API call.
+	registrations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "argocd_cluster_registrar_registrations",
+		Help: "Cluster registrations this instance owns, by state.",
+	}, []string{"state"})
+
+	unroutedSecrets = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "argocd_cluster_registrar_unrouted_secrets",
+		Help: "Owned cluster Secrets recording no source namespace, which no reconcile key can ever collect.",
+	})
+)
+
+// The two states a registration can be in. Demoted means hidden from ArgoCD but
+// kept, which is what a rename leaves behind.
+const (
+	stateActive  = "active"
+	stateDemoted = "demoted"
+)
+
+// conflictReasons is every value the reason label can take. One list, so that
+// publishing them at zero and asserting on them cannot drift apart.
+var conflictReasons = []string{
+	conflictNotManaged,
+	conflictOrphanClusterMismatch,
+	conflictIncumbent,
+	conflictContestedName,
+	conflictCreateRace,
+}
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		conflictsTotal, adoptionsTotal, registrations, unroutedSecrets)
+
+	// Published at zero from the start. A counter that has never been incremented
+	// is absent from /metrics entirely, and an absent series makes
+	// `increase(...[15m]) > 0` silently unevaluable rather than false, so an alert
+	// written against it never fires and never says why.
+	for _, reason := range conflictReasons {
+		conflictsTotal.WithLabelValues(reason)
+	}
+	registrations.WithLabelValues(stateActive)
+	registrations.WithLabelValues(stateDemoted)
+}

--- a/internal/registrar/metrics.go
+++ b/internal/registrar/metrics.go
@@ -7,28 +7,15 @@ import (
 
 // Metrics for the outcomes a log line alone cannot be alerted on.
 //
-// WHY THESE ARE PACKAGE-LEVEL rather than a field on Registrar, which is how the
-// logger is threaded: controller-runtime's Registry is a process global and
-// MustRegister PANICS on a duplicate. One Registrar per process makes an instance
-// field buy nothing, and the test binary builds dozens of them by struct literal,
-// so registering in a constructor would panic on the second one and a field left
-// nil would panic in production on whichever path forgot to guard it.
+// Package-level, not a Registrar field: the Registry is a process global and
+// MustRegister panics on a duplicate, so registering per instance would panic on
+// the second Registrar the test binary builds.
 //
-// WHY THE LABELS ARE ALL CONSTANTS. Every label value below comes from a closed
-// set fixed at compile time. Nothing here is a cluster name, a namespace or
-// anything else read off an object a tenant can create. That is deliberate on the
-// conflict path especially, which is the one path that exists because somebody
-// may be acting in bad faith: labelling by cluster name would let anyone able to
-// label a namespace mint unbounded series in the monitoring system.
-//
-// WHY THERE IS NO PER-CONFLICT GAUGE. A gauge keyed on the contested name and the
-// two namespaces would answer "which cluster is contested right now", and it is
-// tempting. It cannot be cleared. When the losing claimant's namespace is
-// deleted, ReconcileOne takes the NotFound branch and never reaches apply, so
-// nothing is left to zero the series and it alerts forever on a conflict that no
-// longer exists. The identity lives in the log line, which carries the cluster,
-// both namespaces and the reason. The metric's job is to make that line worth
-// looking for.
+// Every label value below is a compile-time constant. Nothing here is a cluster
+// name or a namespace, which on the conflict path would be attacker-chosen
+// cardinality. Which cluster is contested stays in the log line, and so does the
+// reason a per-conflict gauge is absent: it could never be cleared, since a
+// deleted claimant namespace never reaches the code that would zero it.
 var (
 	conflictsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "argocd_cluster_registrar_conflicts_total",

--- a/internal/registrar/metrics_test.go
+++ b/internal/registrar/metrics_test.go
@@ -1,0 +1,197 @@
+package registrar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	coreV1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// conflictCounts snapshots every reason at once.
+//
+// DELTAS, never absolute values. The collectors are process-global and every
+// test in this binary shares them, so an absolute assertion depends on which
+// other tests ran first: TestEveryReturnPathRequeues alone produces a
+// not_managed conflict. That is precisely how a test in this repo has passed by
+// iteration-order luck before.
+func conflictCounts(t *testing.T) map[string]float64 {
+	t.Helper()
+	out := make(map[string]float64, len(conflictReasons))
+	for _, r := range conflictReasons {
+		out[r] = testutil.ToFloat64(conflictsTotal.WithLabelValues(r))
+	}
+	return out
+}
+
+// Each refusal increments its own reason and nothing else.
+//
+// Asserting only that the total moved would pass just as happily if every
+// refusal were labelled the same, which is the failure this is written against:
+// the refusal is correct either way and only the counter lies. Requiring the
+// other four to stay put is what makes the label mean something.
+func TestEveryConflictReasonIsCountedUnderItsOwnLabel(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		want  string
+		ns    string
+		build func(t *testing.T) *Registrar
+	}{
+		{
+			name: "a Secret we do not own at all",
+			want: conflictNotManaged,
+			ns:   testNS,
+			build: func(*testing.T) *Registrar {
+				hand := &coreV1.Secret{ObjectMeta: metaV1.ObjectMeta{
+					Name:      "cluster-a",
+					Namespace: testTargetNS,
+					Labels:    map[string]string{argoSecretTypeLabel: argoSecretTypeValue},
+				}}
+				r, _ := newTestRegistrar(
+					managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"), hand)
+				return r
+			},
+		},
+		{
+			name: "an orphan naming a different cluster",
+			want: conflictOrphanClusterMismatch,
+			ns:   testNS,
+			build: func(*testing.T) *Registrar {
+				existing := registeredSecret("a", testNS)
+				delete(existing.Labels, SourceNamespaceLabel(testPrefix))
+				existing.Labels[ClusterLabel(testPrefix)] = "somethingelse"
+				r, _ := newTestRegistrar(
+					managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"), existing)
+				return r
+			},
+		},
+		{
+			name: "a name another live namespace holds",
+			want: conflictIncumbent,
+			ns:   testNS,
+			build: func(*testing.T) *Registrar {
+				r, _ := newTestRegistrar(
+					managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"),
+					registeredSecret("a", "k3k-incumbent"))
+				return r
+			},
+		},
+		{
+			name: "an unclaimed name an older namespace also wants",
+			want: conflictContestedName,
+			ns:   "k3k-younger",
+			build: func(t *testing.T) *Registrar {
+				r, c := newTestRegistrar(
+					managedNSAt("k3k-older", "a", 2*testHour),
+					kubeconfigSecret("k3k-older", "k3k-a-kubeconfig"),
+					managedNSAt("k3k-younger", "a", testHour),
+					kubeconfigSecret("k3k-younger", "k3k-a-kubeconfig"),
+				)
+				// With a registration already present this would refuse as an
+				// incumbency instead, and pass under the wrong label.
+				if secretExists(t, c, "cluster-a") {
+					t.Fatal("this case must reach the create path")
+				}
+				return r
+			},
+		},
+		{
+			name: "two workers creating the same Secret at once",
+			want: conflictCreateRace,
+			ns:   testNS,
+			build: func(*testing.T) *Registrar {
+				r, c := newTestRegistrar(
+					managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"))
+				c.PrependReactor("create", resourceSecrets, func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apiErrors.NewAlreadyExists(
+						schema.GroupResource{Resource: resourceSecrets}, "cluster-a")
+				})
+				return r
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.build(t)
+			before := conflictCounts(t)
+
+			if _, err := r.ReconcileOne(context.Background(), tc.ns); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			after := conflictCounts(t)
+			for _, reason := range conflictReasons {
+				delta := after[reason] - before[reason]
+				want := float64(0)
+				if reason == tc.want {
+					want = 1
+				}
+				if delta != want {
+					t.Errorf("conflicts_total{reason=%q} moved by %v, want %v",
+						reason, delta, want)
+				}
+			}
+		})
+	}
+}
+
+// Adoption is a success, not a refusal, so it is counted somewhere else and a
+// reader looking for it beside the conflict counter will not find it.
+func TestAdoptingAnOrphanIsCountedSeparatelyFromRefusals(t *testing.T) {
+	existing := registeredSecret("a", testNS)
+	delete(existing.Labels, SourceNamespaceLabel(testPrefix))
+	r, _ := newTestRegistrar(
+		managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"), existing)
+
+	beforeAdopt := testutil.ToFloat64(adoptionsTotal)
+	beforeConflict := conflictCounts(t)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if got := testutil.ToFloat64(adoptionsTotal) - beforeAdopt; got != 1 {
+		t.Errorf("adoptions_total moved by %v, want 1", got)
+	}
+	after := conflictCounts(t)
+	for _, reason := range conflictReasons {
+		if d := after[reason] - beforeConflict[reason]; d != 0 {
+			t.Errorf("an adoption was also counted as a conflict{reason=%q}", reason)
+		}
+	}
+}
+
+// The audit pass reports how many registrations exist and how many are hidden
+// from ArgoCD, which is the question the demotion TTL exists to answer.
+//
+// Gauges are asserted ABSOLUTELY, unlike the counters above: Set overwrites, so
+// the value after the pass is entirely determined by this fixture. Asserting
+// both states in one pass is what stops a leftover value from an earlier test
+// satisfying either one on its own.
+func TestDemotedRegistrationsAreCounted(t *testing.T) {
+	demotedNames := []string{"old1", "old2", "old3"}
+	objs := make([]runtime.Object, 0, len(demotedNames)+1)
+	objs = append(objs, registeredSecret("live", testNS))
+	for _, name := range demotedNames {
+		demoted := registeredSecret(name, testNS)
+		delete(demoted.Labels, argoSecretTypeLabel)
+		demoted.Labels[OrphanedSecretTypeLabel(testPrefix)] = argoSecretTypeValue
+		objs = append(objs, demoted)
+	}
+	r, _ := newTestRegistrar(objs...)
+
+	if err := r.AuditUnrouted(context.Background()); err != nil {
+		t.Fatalf("audit: %v", err)
+	}
+
+	if got := testutil.ToFloat64(registrations.WithLabelValues(stateDemoted)); got != 3 {
+		t.Errorf("registrations{state=demoted} = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(registrations.WithLabelValues(stateActive)); got != 1 {
+		t.Errorf("registrations{state=active} = %v, want 1", got)
+	}
+}

--- a/internal/registrar/pin_test.go
+++ b/internal/registrar/pin_test.go
@@ -1,0 +1,186 @@
+package registrar
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// Pinning the registration a live namespace is actively using must stick.
+//
+// This is the documented case, and it was the one that did not work: apply's
+// prefixed-label sweep removed the pin on the very next reconcile, and changed()
+// reported the pin itself as drift, so the update that stripped it ran even when
+// nothing else had moved. The operator set the label, the API accepted it, and it
+// was gone within one interval. Every existing prune test pinned a Secret that
+// apply never touches, so all five passed throughout.
+func TestPinningAnActiveRegistrationSurvivesReconcile(t *testing.T) {
+	existing := registeredSecret("a", testNS)
+	existing.Labels[PruneLabel(testPrefix)] = PruneDisabled
+	r, c := newTestRegistrar(
+		managedNS(testNS, "a"),
+		kubeconfigSecret(testNS, "k3k-a-kubeconfig"),
+		existing,
+	)
+
+	for i := range 3 {
+		if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+	}
+
+	got := getSecret(t, c, "cluster-a")
+	if v := got.Labels[PruneLabel(testPrefix)]; v != PruneDisabled {
+		t.Errorf("prune label = %q, want %q: the pin was swept off the registration "+
+			"it was protecting", v, PruneDisabled)
+	}
+}
+
+// The exemption is for the pin ALONE. The demotion labels must still be swept,
+// because that sweep is what restores a registration when a rename is reverted.
+func TestTheDemotionLabelsAreStillSweptOnRegistration(t *testing.T) {
+	existing := registeredSecret("a", testNS)
+	existing.Labels[OrphanedSecretTypeLabel(testPrefix)] = argoSecretTypeValue
+	existing.Labels[SupersededByLabel(testPrefix)] = "cluster-a2"
+	existing.Labels[StaleSinceLabel(testPrefix)] = "20260101T000000Z"
+	r, c := newTestRegistrar(
+		managedNS(testNS, "a"),
+		kubeconfigSecret(testNS, "k3k-a-kubeconfig"),
+		existing,
+	)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := getSecret(t, c, "cluster-a")
+	for _, k := range []string{
+		OrphanedSecretTypeLabel(testPrefix),
+		SupersededByLabel(testPrefix),
+		StaleSinceLabel(testPrefix),
+	} {
+		if v, ok := got.Labels[k]; ok {
+			t.Errorf("%s = %q, want it swept; a reverted rename would never restore "+
+				"the registration", k, v)
+		}
+	}
+}
+
+// A pinned registration must not be rewritten on every pass either.
+//
+// changed() reading the pin as drift meant a write per interval, forever, against
+// a credential-bearing Secret, each one invalidating ArgoCD's cluster cache.
+func TestAPinnedRegistrationIsNotRewrittenEveryPass(t *testing.T) {
+	existing := registeredSecret("a", testNS)
+	existing.Labels[PruneLabel(testPrefix)] = PruneDisabled
+	want := registeredSecret("a", testNS)
+	if changed(existing, want, testPrefix) {
+		t.Error("the pin alone counts as drift, so a pinned registration is written " +
+			"on every reconcile forever")
+	}
+}
+
+// A delete that loses a UID precondition leaves the Secret in place deliberately,
+// so the key must stay queued.
+//
+// Reporting it as finished retires the key, and the source namespace is gone, so
+// nothing can ever enqueue it again: the registration outlives its cluster until
+// someone restarts the process. That discards exactly the recovery the UID
+// precondition was added to provide.
+func TestAConflictedDeleteKeepsTheKeyQueued(t *testing.T) {
+	r, c := newTestRegistrar(registeredSecret("gone", "k3k-gone"))
+	c.PrependReactor("delete", resourceSecrets, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apiErrors.NewConflict(
+			schema.GroupResource{Resource: resourceSecrets}, "cluster-gone", nil)
+	})
+
+	finished, err := r.ReconcileOne(context.Background(), "k3k-gone")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-gone") {
+		t.Fatal("the fixture is wrong: the Secret should have survived the conflict")
+	}
+	if finished {
+		t.Error("the key was retired while its registration is still there; its " +
+			"namespace is gone, so nothing will ever visit it again")
+	}
+}
+
+// A delete that genuinely removes the object still retires the key, or every
+// namespace ever seen is revisited forever.
+func TestASuccessfulDeleteStillRetiresTheKey(t *testing.T) {
+	r, c := newTestRegistrar(registeredSecret("gone", "k3k-gone"))
+	finished, err := r.ReconcileOne(context.Background(), "k3k-gone")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if secretExists(t, c, "cluster-gone") {
+		t.Fatal("the orphan was not deleted")
+	}
+	if !finished {
+		t.Error("a fully collected namespace must not stay on the requeue treadmill")
+	}
+}
+
+// tls-server-name must reach ArgoCD.
+//
+// A kubeconfig reached by IP whose certificate is issued for a name depends on
+// it. Dropping it yields a registration with the right CA and the right
+// credentials that still fails hostname verification, which is the same class of
+// unexplainable failure the file-path CA rejection exists to prevent.
+func TestTLSServerNameIsCarriedThrough(t *testing.T) {
+	const kc = `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://10.0.0.5:6443
+    certificate-authority-data: Y2FkYXRh
+    tls-server-name: kubernetes.default.svc
+users:
+- name: u
+  user:
+    client-certificate-data: Y2VydGRhdGE=
+    client-key-data: a2V5ZGF0YQ==
+contexts:
+- name: u@c
+  context:
+    cluster: c
+    user: u
+current-context: u@c
+`
+	_, cfg, err := parseKubeconfig([]byte(kc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var got argoClusterConfig
+	if err := json.Unmarshal([]byte(cfg), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.TLSClientConfig.ServerName != "kubernetes.default.svc" {
+		t.Errorf("serverName = %q, want kubernetes.default.svc; the registration "+
+			"would fail hostname verification", got.TLSClientConfig.ServerName)
+	}
+	if !strings.Contains(cfg, "serverName") {
+		t.Error("serverName is absent from the marshalled config ArgoCD reads")
+	}
+}
+
+// A kubeconfig without it must not gain an empty field, which ArgoCD would read
+// as a server name of "".
+func TestNoTLSServerNameEmitsNoServerName(t *testing.T) {
+	_, cfg, err := parseKubeconfig([]byte(k3kKubeconfig))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if strings.Contains(cfg, "serverName") {
+		t.Errorf("config carries an empty serverName: %s", cfg)
+	}
+}

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -317,6 +317,13 @@ type Config struct {
 
 	// DryRun logs what would change without writing anything.
 	DryRun bool
+
+	// DemotedTTL is how long a demoted registration is kept before it is deleted
+	// outright. Zero, the default, keeps them indefinitely.
+	//
+	// Bounds how far rename debris accumulates, at the price of bounding how long
+	// a mistaken rename can still be reverted. Hence opt-in.
+	DemotedTTL time.Duration
 }
 
 // Registrar reconciles child-cluster kubeconfigs into ArgoCD cluster Secrets.
@@ -433,6 +440,10 @@ func (c Config) Validate() error {
 			return fmt.Errorf("provider %q: secret name pattern %q is not a valid glob: %w",
 				p.Name, p.SecretNamePattern, err)
 		}
+	}
+	// Negative is a typo, not "disabled", and would expire everything on sight.
+	if c.DemotedTTL < 0 {
+		return fmt.Errorf("--demoted-ttl must not be negative, got %s", c.DemotedTTL)
 	}
 	if p := c.LabelPrefix; p != "" && !strings.HasSuffix(p, "/") {
 		// Without the slash the keys become nonsense like "example.commanaged-by"
@@ -1424,10 +1435,21 @@ func (r *Registrar) collectOne(ctx context.Context, nsName string, exists bool, 
 		}
 
 		if s.Labels[r.orphanedSecretTypeLabel()] != "" {
-			// Already demoted on an earlier pass. Nothing to do, and nothing
-			// worth repeating every reconcile.
-			r.log.Debug("superseded registration is already demoted",
-				slog.String("secret", s.Name), slog.String("supersededBy", applied))
+			// Demoted on an earlier pass. Kept until it outlives the TTL, if one is
+			// set. Below the applied == "" guard on purpose: a terminating namespace
+			// can still come back, which a demotion survives and a delete does not.
+			// No error return: every uncertain answer is "keep it", so there is
+			// nothing a caller could do differently.
+			if !r.demotedTTLExpired(s) {
+				r.log.Debug("superseded registration is already demoted",
+					slog.String("secret", s.Name), slog.String("supersededBy", applied))
+				continue
+			}
+			if err := r.deleteExpired(ctx, s); err != nil {
+				errs = append(errs, err.Error())
+				continue
+			}
+			remaining--
 			continue
 		}
 
@@ -1448,6 +1470,72 @@ func (r *Registrar) collectOne(ctx context.Context, nsName string, exists bool, 
 		return remaining, fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
 	return remaining, nil
+}
+
+// demotedTTLExpired reports whether a demoted registration has outlived
+// Config.DemotedTTL.
+//
+// Every uncertain answer is "no", as with collectStaleUID's missing UID. Note
+// time.Parse returns the ZERO time on failure, so an ignored error here would
+// age every demoted registration by two millennia and delete the fleet.
+func (r *Registrar) demotedTTLExpired(s *coreV1.Secret) bool {
+	if r.cfg.DemotedTTL <= 0 {
+		return false
+	}
+	stamp := s.Labels[r.staleSinceLabel()]
+	if stamp == "" {
+		// Demoted before the label existed, or by hand.
+		r.log.Debug("demoted registration carries no stale-since stamp; it will not expire",
+			slog.String("secret", s.Name), slog.String("label", r.staleSinceLabel()))
+		return false
+	}
+	since, err := time.Parse(staleSinceFormat, stamp)
+	if err != nil {
+		// Warn: keeping it is safe, but indistinguishable from a broken TTL.
+		r.log.Warn("demoted registration has an unreadable stale-since stamp; it will not expire",
+			slog.String("secret", s.Name), slog.String("staleSince", stamp),
+			slog.Any("error", err))
+		return false
+	}
+	// A future stamp gives a negative age, so clock skew needs no special case.
+	return time.Since(since) > r.cfg.DemotedTTL
+}
+
+// deleteExpired removes a demoted registration that has outlived its TTL.
+//
+// Not deleteOrphan: different proof, so a different message, and stricter
+// preconditions. UID *and* resourceVersion, because the race here is a REVERTED
+// rename, and a revert goes through apply's read-modify-write, which preserves
+// the UID. Only the resourceVersion moves.
+func (r *Registrar) deleteExpired(ctx context.Context, s *coreV1.Secret) error {
+	if r.cfg.DryRun {
+		r.log.Info("[dry-run] would delete expired demoted cluster secret",
+			slog.String("secret", s.Name), slog.String("staleSince", s.Labels[r.staleSinceLabel()]))
+		return nil
+	}
+	rv := s.ResourceVersion
+	err := r.client.CoreV1().Secrets(r.cfg.TargetNamespace).Delete(ctx, s.Name, metaV1.DeleteOptions{
+		Preconditions: &metaV1.Preconditions{UID: &s.UID, ResourceVersion: &rv},
+	})
+	switch {
+	case err == nil:
+		r.log.Info("deleted a demoted registration that outlived its TTL",
+			slog.String("secret", s.Name), slog.String("cluster", s.Labels[r.clusterLabel()]),
+			slog.String("staleSince", s.Labels[r.staleSinceLabel()]),
+			slog.Duration("ttl", r.cfg.DemotedTTL))
+		return nil
+	case apiErrors.IsNotFound(err):
+		return nil
+	case apiErrors.IsConflict(err):
+		// Written between the read and the delete, most likely a reverted rename
+		// restoring it. Leave it; the next pass reads the new state and decides
+		// again.
+		r.log.Info("demoted registration changed before its TTL delete; leaving it",
+			slog.String("secret", s.Name))
+		return nil
+	default:
+		return fmt.Errorf("delete expired %s: %w", s.Name, err)
+	}
 }
 
 // collectStaleUID removes registrations whose recorded source namespace has been

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -574,6 +574,10 @@ func (r *Registrar) ReconcileOne(ctx context.Context, nsName string) (bool, erro
 			// already taken by the error itself, and a TextHandler emits both
 			// rather than choosing, which would break anything already grepping
 			// the existing field.
+			// The one place every refusal passes through, whichever check produced
+			// it, which is why the counter lives here rather than at the five sites
+			// that construct the error.
+			conflictsTotal.WithLabelValues(conflict.reason).Inc()
 			r.log.Error("refused to register cluster", slog.String("cluster", c.cluster),
 				slog.String("namespace", c.namespace),
 				slog.String("conflict", conflict.reason), slog.Any("reason", err))
@@ -605,15 +609,28 @@ func (r *Registrar) AuditUnrouted(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list cluster secrets (%s): %w", selector, err)
 	}
+	// Counted while we are here. This LIST is the only place anything sees the
+	// whole owned population at once, so the gauges are free; taking them anywhere
+	// else would mean listing the ArgoCD namespace again for no other reason.
+	var active, demoted, unrouted int
 	for i := range secrets.Items {
 		s := &secrets.Items[i]
+		if s.Labels[r.orphanedSecretTypeLabel()] != "" {
+			demoted++
+		} else {
+			active++
+		}
 		if s.Labels[r.sourceNamespaceLabel()] != "" {
 			continue
 		}
+		unrouted++
 		r.log.Warn("owned cluster secret records no source namespace; it can never be collected",
 			slog.String("secret", s.Name), slog.String("label", r.sourceNamespaceLabel()),
 			slog.String("fix", "restore the label, or delete the secret if the cluster is gone"))
 	}
+	registrations.WithLabelValues(stateActive).Set(float64(active))
+	registrations.WithLabelValues(stateDemoted).Set(float64(demoted))
+	unroutedSecrets.Set(float64(unrouted))
 	return nil
 }
 
@@ -1054,6 +1071,10 @@ func (r *Registrar) checkOwnership(existing *coreV1.Secret, c child) error {
 				r.cfg.TargetNamespace, existing.Name, r.clusterLabel(),
 				existing.Labels[r.clusterLabel()], c.cluster, c.namespace)
 		}
+		// Counted here rather than at the refusal choke point, because this branch
+		// is a SUCCESS: it returns nil and the registration proceeds. Look for it
+		// alongside the conflict counter and you will conclude it is missing.
+		adoptionsTotal.Inc()
 		r.log.Warn("adopting an owned cluster secret that records no source namespace",
 			slog.String("secret", existing.Name), slog.String("cluster", c.cluster),
 			slog.String("namespace", c.namespace),

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -454,6 +454,16 @@ func (c Config) Validate() error {
 	if c.DemotedTTL < 0 {
 		return fmt.Errorf("--demoted-ttl must not be negative, got %s", c.DemotedTTL)
 	}
+	// Empty is not "use the default" here. With no prefix, propagatedLabels
+	// matches EVERY label on the source namespace and the reserved list computes
+	// as bare names that match nothing actually written, so a tenant could
+	// propagate argocd.argoproj.io/secret-type off its own namespace. The
+	// constructor happens to repair it, but a caller that validates without going
+	// through the constructor would get a silently different trust boundary.
+	if c.LabelPrefix == "" {
+		return fmt.Errorf("--label-prefix must not be empty; it is what keeps a source " +
+			"namespace from propagating labels this tool reserves")
+	}
 	if p := c.LabelPrefix; p != "" && !strings.HasSuffix(p, "/") {
 		// Without the slash the keys become nonsense like "example.commanaged-by"
 		// while propagatedLabels still matches "example.com/...", so it half-works.

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -2,6 +2,8 @@ package registrar
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -238,6 +240,27 @@ var presets = map[string]Provider{
 		SecretNamePattern: "*-kubeconfig",
 		SecretKeys:        []string{"value"},
 	},
+}
+
+// LeaderElectionID derives the lease name from the two values that decide whether
+// two instances collide at all.
+//
+// NOT the release name, and not either value alone. Ownership is established
+// purely by label-prefix and managed-by, so two deployments differing only in
+// name contend for the same cluster Secrets and must contend for the same lease;
+// managed-by alone would over-serialise two installs that never meet.
+//
+// Hashed because labelPrefix contains a "/", which is illegal in an object name,
+// and managedBy is a label value, which permits characters a name does not.
+//
+// The chart computes the same thing in _helpers.tpl. The two must agree, or an
+// instance deployed from a plain manifest takes a different lease from a
+// chart-deployed one with identical configuration and both reconcile, which is
+// the state leader election exists to prevent. TestLeaderElectionIDMatchesTheChart
+// pins them together.
+func LeaderElectionID(labelPrefix, managedBy string) string {
+	sum := sha256.Sum256([]byte(labelPrefix + "|" + managedBy))
+	return "acr-" + hex.EncodeToString(sum[:])[:16]
 }
 
 // Preset returns a built-in provider by name.

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -441,6 +441,15 @@ func (c Config) Validate() error {
 				p.Name, p.SecretNamePattern, err)
 		}
 	}
+	// A prefix that ArgoCD's own key falls under would let a source namespace
+	// propagate `argocd.argoproj.io/secret-type` -- it is not a reserved suffix,
+	// so nothing withholds it -- and the propagated labels are copied last, so it
+	// would override the key this tool sets. Absurd to configure on purpose, but
+	// the trust boundary should not depend on that.
+	if c.LabelPrefix != "" && strings.HasPrefix(argoSecretTypeLabel, c.LabelPrefix) {
+		return fmt.Errorf("--label-prefix %q would let a source namespace override %q",
+			c.LabelPrefix, argoSecretTypeLabel)
+	}
 	// Negative is a typo, not "disabled", and would expire everything on sight.
 	if c.DemotedTTL < 0 {
 		return fmt.Errorf("--demoted-ttl must not be negative, got %s", c.DemotedTTL)
@@ -1254,7 +1263,16 @@ func (r *Registrar) apply(ctx context.Context, c child) error {
 	maps.Copy(updated.Labels, want.Labels)
 	// Drop prefixed labels that no longer exist upstream, so a cluster can be
 	// opted back OUT of a selector (e.g. flux=true) once it was opted in.
+	//
+	// Except the prune opt-out, which is set on the cluster Secret by whoever owns
+	// the ArgoCD namespace and has no upstream to be absent from. Sweeping it was
+	// how pinning a LIVE registration silently undid itself one reconcile later:
+	// exactly the case the feature is documented for. The demotion labels are
+	// deliberately still swept, because that is the self-heal on a reverted rename.
 	for k := range updated.Labels {
+		if k == r.pruneLabel() {
+			continue
+		}
 		if strings.HasPrefix(k, r.cfg.LabelPrefix) {
 			if _, keep := want.Labels[k]; !keep {
 				delete(updated.Labels, k)
@@ -1340,8 +1358,13 @@ func changed(existing, want *coreV1.Secret, labelPrefix string) bool {
 		}
 	}
 	// A label removed from the source must disappear here too, or a cluster could
-	// never be opted OUT of Flux once opted in.
+	// never be opted OUT of Flux once opted in. The prune opt-out is exempt for
+	// the same reason apply does not sweep it: it is set here, not upstream, so
+	// reading it as drift makes every pinned registration write on every pass.
 	for k := range existing.Labels {
+		if k == PruneLabel(labelPrefix) {
+			continue
+		}
 		if strings.HasPrefix(k, labelPrefix) {
 			if _, ok := want.Labels[k]; !ok {
 				return true
@@ -1408,11 +1431,18 @@ func (r *Registrar) collectOne(ctx context.Context, nsName string, exists bool, 
 		}
 
 		if !exists {
-			if err := r.deleteOrphan(ctx, s, nsName); err != nil {
+			removed, err := r.deleteOrphan(ctx, s, nsName)
+			if err != nil {
 				errs = append(errs, err.Error())
 				continue
 			}
-			remaining--
+			// Only when it is genuinely gone. A UID conflict leaves the Secret in
+			// place on purpose, and counting it as removed retires the key: the
+			// source namespace no longer exists, so nothing can ever enqueue it
+			// again and the registration outlives its cluster until a restart.
+			if removed {
+				remaining--
+			}
 			continue
 		}
 
@@ -1582,7 +1612,9 @@ func (r *Registrar) collectStaleUID(ctx context.Context, nsName string, uid type
 		r.log.Info("source namespace was replaced by a different one of the same name",
 			slog.String("secret", s.Name), slog.String("namespace", nsName),
 			slog.String("recordedUID", recorded), slog.String("currentUID", string(uid)))
-		if err := r.deleteOrphan(ctx, s, nsName); err != nil {
+		// The bool is genuinely unused here: collectStaleUID reports only errors,
+		// and nothing downstream counts what it removed.
+		if _, err := r.deleteOrphan(ctx, s, nsName); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}
@@ -1594,11 +1626,14 @@ func (r *Registrar) collectStaleUID(ctx context.Context, nsName string, uid type
 }
 
 // deleteOrphan removes a registration whose source namespace is provably gone.
-func (r *Registrar) deleteOrphan(ctx context.Context, s *coreV1.Secret, nsName string) error {
+// The bool reports whether the object is gone, which is NOT the same as "no error
+// occurred": a UID conflict is reported as success because it needs no retry, and
+// the caller must not count it as one fewer registration.
+func (r *Registrar) deleteOrphan(ctx context.Context, s *coreV1.Secret, nsName string) (bool, error) {
 	if r.cfg.DryRun {
 		r.log.Info("[dry-run] would delete orphaned cluster secret",
 			slog.String("secret", s.Name), slog.String("namespace", nsName))
-		return nil
+		return false, nil
 	}
 	// Preconditioned on the Secret's own UID. Under the poll loop the gap between
 	// the existence proof and this call was microseconds and single-threaded; under
@@ -1612,19 +1647,20 @@ func (r *Registrar) deleteOrphan(ctx context.Context, s *coreV1.Secret, nsName s
 	case err == nil:
 		r.log.Info("deregistered cluster (source namespace gone)",
 			slog.String("secret", s.Name), slog.String("namespace", nsName))
-		return nil
+		return true, nil
 	case apiErrors.IsNotFound(err):
-		return nil
+		// Already gone, by whatever hand.
+		return true, nil
 	case apiErrors.IsConflict(err):
 		// The Secret was replaced between the read and the delete, so it is no
 		// longer the object the proof was about. Leave it; the next reconcile sees
 		// the new one and decides again.
 		r.log.Info("cluster secret changed identity before deletion; leaving it",
 			slog.String("secret", s.Name), slog.String("namespace", nsName))
-		return nil
+		return false, nil
 	default:
 		// Keep going. One Secret held up by a finalizer or an admission webhook
 		// must not stall collection for the rest.
-		return fmt.Errorf("delete %s: %w", s.Name, err)
+		return false, fmt.Errorf("delete %s: %w", s.Name, err)
 	}
 }

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -569,8 +569,14 @@ func (r *Registrar) ReconcileOne(ctx context.Context, nsName string) (bool, erro
 			//
 			// Skip collection: a refused claimant vouches for nothing, and its own
 			// earlier registrations must not be read as superseded.
+			//
+			// The reason is logged under "conflict", NOT "reason": that key is
+			// already taken by the error itself, and a TextHandler emits both
+			// rather than choosing, which would break anything already grepping
+			// the existing field.
 			r.log.Error("refused to register cluster", slog.String("cluster", c.cluster),
-				slog.String("namespace", c.namespace), slog.Any("reason", err))
+				slog.String("namespace", c.namespace),
+				slog.String("conflict", conflict.reason), slog.Any("reason", err))
 			return false, nil
 		}
 		r.log.Error("failed to register cluster",
@@ -706,16 +712,47 @@ func (e *apiFailure) Unwrap() error { return e.err }
 //
 // Reconcile must not count it toward the pass's error return. A contested name is
 // a configuration mistake that persists until a human fixes it, so treating it as
-// an error would fail every pass forever and, once there is a metric, pump it
-// forever too. It is still logged at Error, because a silently resolved conflict
-// over a credential-bearing Secret is the actual hazard.
-type conflictError struct{ err error }
+// an error would fail every pass forever and pump the conflict metric forever too.
+// It is still logged at Error, because a silently resolved conflict over a
+// credential-bearing Secret is the actual hazard.
+//
+// The reason travels on the error rather than being re-derived from its text: it
+// is the metric's only label, and matching on message wording would make a
+// reworded sentence a silent monitoring regression.
+type conflictError struct {
+	reason string
+	err    error
+}
 
 func (e *conflictError) Error() string { return e.err.Error() }
 func (e *conflictError) Unwrap() error { return e.err }
 
-func conflictf(format string, a ...any) error {
-	return &conflictError{fmt.Errorf(format, a...)}
+// The closed set of reasons a claim can be refused. Every value is a constant
+// because these are metric label values: anything derived from a namespace or a
+// cluster name would be attacker-chosen cardinality on the one path that is
+// explicitly adversarial.
+const (
+	// conflictNotManaged is a Secret this registrar does not own at all: hand
+	// written, or another instance's.
+	conflictNotManaged = "not_managed"
+	// conflictOrphanClusterMismatch is an owned Secret recording no source
+	// namespace whose cluster label names a different cluster, so adopting it
+	// would repoint someone else's registration.
+	conflictOrphanClusterMismatch = "orphan_cluster_mismatch"
+	// conflictIncumbent is the ordinary case: the name is held by another live
+	// namespace and the holder keeps it.
+	conflictIncumbent = "incumbent"
+	// conflictContestedName is an unclaimed name several namespaces want, awarded
+	// to the oldest.
+	conflictContestedName = "contested_name"
+	// conflictCreateRace is benign and self-resolving: two workers created the
+	// same Secret at once. Expected during a leader-election handover, so it is
+	// counted separately rather than alerted on.
+	conflictCreateRace = "create_race"
+)
+
+func conflictf(reason, format string, a ...any) error {
+	return &conflictError{reason: reason, err: fmt.Errorf(format, a...)}
 }
 
 // discoverOne evaluates a single managed namespace. The bool reports whether a
@@ -984,7 +1021,7 @@ func secretName(cluster string) string { return "cluster-" + cluster }
 func (r *Registrar) checkOwnership(existing *coreV1.Secret, c child) error {
 	if existing.Labels[r.managedByLabel()] != r.cfg.ManagedByValue {
 		// Hand-registered, or another registrar's. Either way not ours to take.
-		return conflictf(
+		return conflictf(conflictNotManaged,
 			"secret %s/%s is not managed by this registrar (%s=%q); "+
 				"refusing to take it over for namespace %s. Rename the cluster, or delete "+
 				"the secret if it is genuinely stale",
@@ -1011,7 +1048,7 @@ func (r *Registrar) checkOwnership(existing *coreV1.Secret, c child) error {
 		// wearing a different hat. Requiring the cluster label to match means an
 		// attacker gains nothing they did not already have.
 		if existing.Labels[r.clusterLabel()] != c.cluster {
-			return conflictf(
+			return conflictf(conflictOrphanClusterMismatch,
 				"secret %s/%s is owned but records no source namespace, and its %s label is %q "+
 					"rather than %q; refusing to adopt it for namespace %s",
 				r.cfg.TargetNamespace, existing.Name, r.clusterLabel(),
@@ -1028,7 +1065,7 @@ func (r *Registrar) checkOwnership(existing *coreV1.Secret, c child) error {
 		// under the same name is a legitimate claimant, and refusing it here
 		// would deadlock: collect() would see a live namespace of that name and
 		// refuse to delete the registration, so neither side could ever move.
-		return conflictf(
+		return conflictf(conflictIncumbent,
 			"cluster %q is registered from namespace %s; refusing to take it over for %s. "+
 				"Two namespaces must not claim one cluster name",
 			c.cluster, src, c.namespace)
@@ -1083,7 +1120,7 @@ func (r *Registrar) claimContestedName(ctx context.Context, c child) error {
 	if winner == "" || winner == c.namespace {
 		return nil
 	}
-	return conflictf(
+	return conflictf(conflictContestedName,
 		"cluster %q is also claimed by namespace %s, which is older; "+
 			"not registering it from %s", c.cluster, winner, c.namespace)
 }
@@ -1137,7 +1174,8 @@ func (r *Registrar) apply(ctx context.Context, c child) error {
 				// Someone wrote it between our Get and our Create. Benign, and
 				// resolved by incumbency on the next pass -- which is also what
 				// keeps this safe once more than one worker reconciles at a time.
-				return conflictf("cluster secret %s was created concurrently; retrying next pass",
+				return conflictf(conflictCreateRace,
+					"cluster secret %s was created concurrently; retrying next pass",
 					want.Name)
 			}
 			return fmt.Errorf("create: %w", err)

--- a/internal/registrar/registrar.go
+++ b/internal/registrar/registrar.go
@@ -173,10 +173,19 @@ type Provider struct {
 	// there instead.
 	SecretNamePattern string
 
-	// SecretKeys are the keys that may hold the kubeconfig, tried in order. A
-	// list rather than a single key because one provisioner can legitimately use
-	// either: Kamaji writes `admin.conf`, or `admin.svc` when its control plane
-	// advertises a service address.
+	// SecretKeys are the keys that may hold the kubeconfig. A list rather than a
+	// single key because one provisioner can legitimately use either: Kamaji
+	// writes `admin.conf`, or `admin.svc` when its control plane advertises a
+	// service address.
+	//
+	// Tried in order, and "tried" means parsed: every key present becomes its own
+	// candidate, so a first key that is half-written or carries a credential we
+	// cannot copy falls through to the next rather than failing the namespace.
+	// The first key that yields a USABLE kubeconfig wins, so where several parse
+	// -- which is the normal Kamaji case, both of its keys being well-formed --
+	// the order declared here is the order that decides.
+	//
+	// Duplicates are rejected by Validate rather than ignored here.
 	SecretKeys []string
 }
 
@@ -203,9 +212,13 @@ var presets = map[string]Provider{
 		SecretNamePattern: "vc-*",
 		SecretKeys:        []string{"config"},
 	},
-	// Kamaji's standalone shape. Note that driving Kamaji through its Cluster API
-	// control-plane provider ALSO produces a second, CAPI-shaped Secret for the
-	// same physical cluster -- see the note on candidate ordering in discover.
+	// Kamaji's standalone shape. Both keys are normally present and both normally
+	// parse, so `admin.conf` wins on order; `admin.svc` is reached when the first
+	// is unusable, or by declaring it first in a custom entry.
+	//
+	// Note that driving Kamaji through its Cluster API control-plane provider ALSO
+	// produces a second, CAPI-shaped Secret for the same physical cluster -- see
+	// the note on candidate ordering in discover.
 	"kamaji": { // #nosec G101 -- see above
 		Name:              "kamaji",
 		SecretNamePattern: "*-admin-kubeconfig",
@@ -400,10 +413,19 @@ func (c Config) Validate() error {
 		if len(p.SecretKeys) == 0 {
 			return fmt.Errorf("provider %q: at least one secret key must be set", p.Name)
 		}
+		seenKey := make(map[string]bool, len(p.SecretKeys))
 		for _, k := range p.SecretKeys {
 			if k == "" {
 				return fmt.Errorf("provider %q: secret key must not be empty", p.Name)
 			}
+			// Rejected rather than quietly ignored, matching the duplicate-name rule
+			// above. Every present key now becomes its own candidate, so a repeated
+			// key would parse the same bytes twice and report the same failure twice
+			// -- and the operator would never learn their values file has a typo.
+			if seenKey[k] {
+				return fmt.Errorf("provider %q: duplicate secret key %q", p.Name, k)
+			}
+			seenKey[k] = true
 		}
 		// A malformed glob is a permanent fault. It used to surface once per
 		// namespace per pass, disguised as "no kubeconfig secret yet".
@@ -754,6 +776,9 @@ func (r *Registrar) discoverOne(ctx context.Context, ns *coreV1.Namespace) (chil
 	// Try candidates in order. A shape match is not a usable kubeconfig: it may
 	// be half-written, or carry an exec credential that cannot be copied into an
 	// ArgoCD Secret, and in both cases the next candidate may be fine.
+	//
+	// Two candidates may be the same Secret under different keys, which is why the
+	// parse errors below are labelled `name[key]` rather than by name alone.
 	var (
 		server, config string
 		provider       string
@@ -801,9 +826,10 @@ type candidate struct {
 	key      string
 }
 
-// findKubeconfigCandidates returns every Secret in ns that matches a configured
-// provider's glob AND carries one of that provider's keys, in the order they
-// should be tried: providers in configured precedence order, then Secret name.
+// findKubeconfigCandidates returns every (Secret, key) pair in ns where the
+// Secret matches a configured provider's glob AND carries that key, in the order
+// they should be tried: providers in configured precedence order, then Secret
+// name, then the order the provider declares its keys.
 //
 // Both conditions matter. A name-only match picks the wrong object whenever a
 // provisioner writes more than one Secret under the same prefix: vcluster's
@@ -813,12 +839,19 @@ type candidate struct {
 // the two happen to sort.
 //
 // A LIST rather than a single answer, because matching the shape is not the same
-// as being usable. Cluster API's contract is satisfied by managed-cloud
-// providers too, and CAPA's EKS path writes a second `<cluster>-user-kubeconfig`
-// -- same glob, same `value` key -- holding an `exec` credential that cannot be
-// copied into an ArgoCD Secret at all. Returning candidates lets the caller fall
-// through to the next one on a parse failure, instead of relying on `k` sorting
-// before `u`.
+// as being usable. That holds at both levels.
+//
+// Across Secrets: Cluster API's contract is satisfied by managed-cloud providers
+// too, and CAPA's EKS path writes a second `<cluster>-user-kubeconfig` -- same
+// glob, same `value` key -- holding an `exec` credential that cannot be copied
+// into an ArgoCD Secret at all. Returning candidates lets the caller fall through
+// to the next one on a parse failure, instead of relying on `k` sorting before
+// `u`.
+//
+// Within one Secret: Kamaji writes `admin.conf` and `admin.svc` side by side, so
+// emitting only the first present key made the second unreachable however broken
+// the first was. Both levels use the same mechanism, because a parse failure is
+// how an unusable candidate announces itself either way.
 func (r *Registrar) findKubeconfigCandidates(ctx context.Context, ns string) ([]candidate, error) {
 	secrets, err := r.client.CoreV1().Secrets(ns).List(ctx, metaV1.ListOptions{})
 	if err != nil {
@@ -860,21 +893,32 @@ func (r *Registrar) findKubeconfigCandidates(ctx context.Context, ns string) ([]
 				continue
 			}
 
-			key := ""
+			// One candidate per key PRESENT, not merely the first one. Kamaji ships
+			// `admin.conf` and `admin.svc` together, so stopping at the first meant
+			// a half-written `admin.conf` put `admin.svc` out of reach and stranded
+			// the namespace -- while Provider.SecretKeys claimed its keys were
+			// "tried in order". They now are.
+			//
+			// Several candidates may therefore share one *coreV1.Secret pointer into
+			// secrets.Items. Read-only, and the caller tells them apart by key.
+			found := 0
 			for _, k := range p.SecretKeys {
-				if _, has := s.Data[k]; has {
-					key = k
-					break
+				if _, has := s.Data[k]; !has {
+					continue
 				}
+				found++
+				out = append(out, candidate{secret: s, provider: p.Name, key: k})
 			}
-			if key == "" {
+			if found == 0 {
 				namedButKeyless = append(namedButKeyless,
 					fmt.Sprintf("%s (provider %s)", s.Name, p.Name))
 				continue
 			}
 
+			// Claimed per SECRET, not per key, and that is what keeps one physical
+			// cluster registered once: a later provider must not re-offer this
+			// object under a key of its own.
 			claimed[s.Name] = true
-			out = append(out, candidate{secret: s, provider: p.Name, key: key})
 		}
 	}
 

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -30,6 +30,9 @@ const (
 	testSourceNS = "k3k-src"
 	// keyConfig is the ArgoCD cluster Secret's credential key.
 	keyConfig = "config"
+	// testServer is a placeholder endpoint for cases where the address itself is
+	// not what is being asserted.
+	testServer = "https://x"
 
 	// Kamaji's two kubeconfig keys. Named because the multi-key tests repeat them
 	// and because which of the two wins is itself the assertion.
@@ -113,7 +116,7 @@ func registeredSecret(cluster, srcNS string) *coreV1.Secret {
 				SourceNamespaceLabel(testPrefix): srcNS,
 			},
 		},
-		Data: map[string][]byte{"name": []byte(cluster), "server": []byte("https://x"), "config": []byte("{}")},
+		Data: map[string][]byte{"name": []byte(cluster), "server": []byte(testServer), "config": []byte("{}")},
 	}
 }
 
@@ -539,7 +542,7 @@ func TestApplyAdoptsSecretWithMatchingClusterLabel(t *testing.T) {
 
 	if err := r.apply(context.Background(), child{
 		cluster: "a", namespace: testSourceNS, namespaceUID: "uid-k3k-a",
-		server: "https://x", config: "{}",
+		server: testServer, config: "{}",
 	}); err != nil {
 		t.Fatalf("apply refused to adopt its own registration: %v", err)
 	}
@@ -671,7 +674,7 @@ func TestCreateRaceReturnsConflict(t *testing.T) {
 
 	err := r.apply(context.Background(), child{
 		cluster: "a", namespace: testSourceNS, namespaceUID: "uid-k3k-a",
-		server: "https://x", config: "{}",
+		server: testServer, config: "{}",
 	})
 	var conflict *conflictError
 	if !errors.As(err, &conflict) {
@@ -1282,5 +1285,94 @@ func TestDuplicateSecretKeysInOneProviderAreRejected(t *testing.T) {
 	}}
 	if err := cfg.Validate(); err == nil {
 		t.Error("a duplicated secret key was accepted")
+	}
+}
+
+// Every way a claim can be refused carries its own reason.
+//
+// The reason is the conflict metric's only label, so a site tagged with the wrong
+// constant is a monitoring bug that no other test can see: the refusal still
+// happens, the Secret is still protected, and only the counter lies. Deriving it
+// from the message text instead would make a reworded sentence a silent
+// regression, which is why it travels on the error.
+func TestEveryRefusalCarriesItsOwnReason(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		want  string
+		build func(t *testing.T) (*Registrar, child)
+	}{
+		{
+			name: "a Secret we do not own at all",
+			want: conflictNotManaged,
+			build: func(*testing.T) (*Registrar, child) {
+				hand := &coreV1.Secret{ObjectMeta: metaV1.ObjectMeta{
+					Name:      "cluster-prod",
+					Namespace: testTargetNS,
+					Labels:    map[string]string{argoSecretTypeLabel: argoSecretTypeValue},
+				}}
+				r, _ := newTestRegistrar(hand)
+				return r, child{cluster: "prod", namespace: "tenant-evil", server: testServer, config: "{}"}
+			},
+		},
+		{
+			name: "an orphan naming a different cluster",
+			want: conflictOrphanClusterMismatch,
+			build: func(*testing.T) (*Registrar, child) {
+				existing := registeredSecret("a", testSourceNS)
+				delete(existing.Labels, SourceNamespaceLabel(testPrefix))
+				existing.Labels[ClusterLabel(testPrefix)] = "somethingelse"
+				r, _ := newTestRegistrar(existing)
+				return r, child{cluster: "a", namespace: testSourceNS, server: testServer, config: "{}"}
+			},
+		},
+		{
+			name: "a name another live namespace holds",
+			want: conflictIncumbent,
+			build: func(*testing.T) (*Registrar, child) {
+				r, _ := newTestRegistrar(registeredSecret("a", "k3k-incumbent"))
+				return r, child{cluster: "a", namespace: "k3k-challenger", server: testServer, config: "{}"}
+			},
+		},
+		{
+			name: "an unclaimed name an older namespace also wants",
+			want: conflictContestedName,
+			build: func(t *testing.T) (*Registrar, child) {
+				// No Secret exists, deliberately: with one present this would take
+				// the incumbency branch instead and pass under the wrong reason.
+				r, c := newTestRegistrar(
+					managedNSAt("k3k-older", "a", 2*time.Hour),
+					managedNSAt("k3k-younger", "a", time.Hour),
+				)
+				if secretExists(t, c, "cluster-a") {
+					t.Fatal("this case must reach the create path, not the incumbency check")
+				}
+				return r, child{cluster: "a", namespace: "k3k-younger", server: testServer, config: "{}"}
+			},
+		},
+		{
+			name: "two workers creating the same Secret at once",
+			want: conflictCreateRace,
+			build: func(*testing.T) (*Registrar, child) {
+				r, c := newTestRegistrar(managedNS(testSourceNS, "a"))
+				c.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apiErrors.NewAlreadyExists(
+						schema.GroupResource{Resource: "secrets"}, "cluster-a")
+				})
+				return r, child{cluster: "a", namespace: testSourceNS, server: testServer, config: "{}"}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, c := tc.build(t)
+			err := r.apply(context.Background(), c)
+			var conflict *conflictError
+			if !errors.As(err, &conflict) {
+				t.Fatalf("apply returned %v, want a conflictError", err)
+			}
+			if conflict.reason != tc.want {
+				t.Errorf("reason = %q, want %q; the conflict metric would count this "+
+					"refusal under the wrong label", conflict.reason, tc.want)
+			}
+		})
 	}
 }

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -1146,6 +1146,9 @@ func TestConfigValidate(t *testing.T) {
 		// Under this prefix a source namespace could propagate
 		// argocd.argoproj.io/secret-type, which is not a reserved suffix, and the
 		// propagated labels are copied last so it would win.
+		// Not "use the default": with no prefix, propagatedLabels matches every
+		// label and the reserved list matches none of the keys actually written.
+		"empty prefix": func(c *Config) { c.LabelPrefix = "" },
 		"prefix that ArgoCD's own key falls under": func(c *Config) {
 			c.LabelPrefix = "argocd.argoproj.io/"
 		},

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -1392,3 +1392,36 @@ func TestEveryRefusalCarriesItsOwnReason(t *testing.T) {
 		})
 	}
 }
+
+// The binary and the chart must derive the same lease name.
+//
+// The chart computes it in _helpers.tpl. If they disagree, an instance deployed
+// from a plain manifest and one deployed by Helm with identical labelPrefix and
+// managedBy contend for the same cluster Secrets while holding different leases,
+// and both reconcile: exactly what leader election is for. The literal below is
+// what `helm template --set leaderElection.enabled=true` renders for the chart's
+// default values, so changing either side alone fails here.
+func TestLeaderElectionIDMatchesTheChart(t *testing.T) {
+	const fromChart = "acr-991221237547448b"
+	if got := LeaderElectionID(DefaultLabelPrefix, "cluster-registrar"); got != fromChart {
+		t.Errorf("LeaderElectionID = %q, chart renders %q", got, fromChart)
+	}
+}
+
+// Two installs that would contend for the same Secrets must contend for the same
+// lease, and two that never meet must not.
+func TestLeaderElectionIDSerialisesExactlyTheCollidingInstalls(t *testing.T) {
+	base := LeaderElectionID(DefaultLabelPrefix, "cluster-registrar")
+	if got := LeaderElectionID(DefaultLabelPrefix, "cluster-registrar"); got != base {
+		t.Error("identical configuration produced different leases")
+	}
+	if got := LeaderElectionID(DefaultLabelPrefix, "other"); got == base {
+		t.Error("a different managed-by shares a lease; installs that never meet are serialised")
+	}
+	if got := LeaderElectionID("example.com/", "cluster-registrar"); got == base {
+		t.Error("a different label-prefix shares a lease")
+	}
+	if errs := validation.IsDNS1123Subdomain(base); len(errs) > 0 {
+		t.Errorf("%q is not a valid object name: %s", base, strings.Join(errs, "; "))
+	}
+}

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -30,6 +30,11 @@ const (
 	testSourceNS = "k3k-src"
 	// keyConfig is the ArgoCD cluster Secret's credential key.
 	keyConfig = "config"
+
+	// Kamaji's two kubeconfig keys. Named because the multi-key tests repeat them
+	// and because which of the two wins is itself the assertion.
+	keyAdminConf = "admin.conf"
+	keyAdminSvc  = "admin.svc"
 	// testNS is the source namespace most fixtures use.
 	testNS = "k3k-a"
 	// k3kServer is the endpoint inside the k3k kubeconfig fixture.
@@ -310,7 +315,7 @@ func secretWith(ns, name, key, body string) *coreV1.Secret {
 func TestMultipleProvidersRegisterSideBySide(t *testing.T) {
 	r, c := newTestRegistrar(
 		managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"),
-		managedNS("tenant-b", "b"), secretWith("tenant-b", "b-admin-kubeconfig", "admin.conf", kamajiKubeconfig),
+		managedNS("tenant-b", "b"), secretWith("tenant-b", "b-admin-kubeconfig", keyAdminConf, kamajiKubeconfig),
 	)
 	r.cfg.Providers = mustPresets(t, "k3k", "kamaji")
 
@@ -355,10 +360,15 @@ func TestGarbageCollectionIsPerClusterAcrossProviders(t *testing.T) {
 // Secrets for one physical cluster: Kamaji's own `<tcp>-admin-kubeconfig`, and a
 // CAPI-shaped `<cluster>-kubeconfig` copied from it. With both presets enabled
 // they both match, and registering each would put one cluster into ArgoCD twice.
+//
+// What this pins is PROVIDER PRECEDENCE. Read it as a guard on the candidate
+// count and you will overrate it: capi's `value` key is absent from the Kamaji
+// Secret, so no change to how keys become candidates can make it fail. The
+// per-Secret `claimed` rule is what it actually holds in place.
 func TestKamajiViaCAPIRegistersOnce(t *testing.T) {
 	r, c := newTestRegistrar(
 		managedNS("tenant-b", "b"),
-		secretWith("tenant-b", "b-admin-kubeconfig", "admin.conf", kamajiKubeconfig),
+		secretWith("tenant-b", "b-admin-kubeconfig", keyAdminConf, kamajiKubeconfig),
 		secretWith("tenant-b", "b-kubeconfig", "value", capiKubeconfig),
 	)
 	r.cfg.Providers = mustPresets(t, "kamaji", "capi")
@@ -1149,5 +1159,128 @@ func TestDiscoverSkipsInvalidClusterNames(t *testing.T) {
 	)
 	if _, ok := discoverNS(t, r, "k3k-bad"); ok {
 		t.Error("expected the invalid cluster name to be skipped")
+	}
+}
+
+// secretWithKeys builds a Secret carrying several keys at once, which is the
+// shape Kamaji actually writes and which no fixture covered before.
+func secretWithKeys(ns, name string, kv map[string]string) *coreV1.Secret {
+	data := make(map[string][]byte, len(kv))
+	for k, v := range kv {
+		data[k] = []byte(v)
+	}
+	return &coreV1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       data,
+	}
+}
+
+// Every key a provider declares that is actually present becomes its own
+// candidate, in declared order.
+//
+// Stopping at the first present key made Provider.SecretKeys' "tried in order"
+// a claim the code did not honour: with both Kamaji keys present there was only
+// ever one candidate, so the second could not be reached however broken the
+// first was.
+func TestOneSecretYieldsOneCandidatePerPresentKey(t *testing.T) {
+	r, _ := newTestRegistrar(
+		managedNS("tenant-c", "c"),
+		secretWithKeys("tenant-c", "c-admin-kubeconfig", map[string]string{
+			keyAdminConf: kamajiKubeconfig,
+			keyAdminSvc:  kamajiSvcKubeconfig,
+		}),
+	)
+	r.cfg.Providers = mustPresets(t, "kamaji")
+
+	got, err := r.findKubeconfigCandidates(context.Background(), "tenant-c")
+	if err != nil {
+		t.Fatalf("find candidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d candidates, want one per present key", len(got))
+	}
+	// Declared order, not map order: Secret.Data is a map, so iterating it rather
+	// than SecretKeys would pass or fail at random.
+	if got[0].key != keyAdminConf || got[1].key != keyAdminSvc {
+		t.Errorf("keys = %q then %q, want admin.conf then admin.svc (the declared order)",
+			got[0].key, got[1].key)
+	}
+	if got[0].secret != got[1].secret {
+		t.Error("the two candidates should share one Secret, not copy it")
+	}
+}
+
+// An unusable first key must fall through to the next, exactly as an unusable
+// first Secret already does.
+//
+// This is the bug B1 names: Kamaji writes admin.conf and admin.svc together, so
+// a half-written admin.conf left the namespace unregistered indefinitely even
+// though a perfectly good kubeconfig sat beside it.
+func TestEveryPresentKeyOnOneSecretIsTriedInOrder(t *testing.T) {
+	r, _ := newTestRegistrar(
+		managedNS("tenant-d", "d"),
+		secretWithKeys("tenant-d", "d-admin-kubeconfig", map[string]string{
+			keyAdminConf: "<html>not a kubeconfig</html>",
+			keyAdminSvc:  kamajiSvcKubeconfig,
+		}),
+	)
+	r.cfg.Providers = mustPresets(t, "kamaji")
+
+	ch, ok := discoverNS(t, r, "tenant-d")
+	if !ok {
+		t.Fatal("a usable admin.svc beside a broken admin.conf produced no registration")
+	}
+	// The exact address, not merely "no error": asserting the fallthrough reached
+	// the SECOND key is the whole point, and the two fixtures differ only here.
+	if ch.server != "https://tenant-00.kamaji.svc:6443" {
+		t.Errorf("server = %q, want admin.svc's address", ch.server)
+	}
+}
+
+// Several candidates, still one registration.
+//
+// Candidate count and registration count are different things: discoverOne stops
+// at the first candidate that parses. Both keys are valid here and point at
+// DIFFERENT servers, so a bug that kept going would be visible as the wrong
+// address rather than as a second Secret.
+func TestTwoKeysOnOneSecretStillRegisterOneCluster(t *testing.T) {
+	r, c := newTestRegistrar(
+		managedNS("tenant-e", "e"),
+		secretWithKeys("tenant-e", "e-admin-kubeconfig", map[string]string{
+			keyAdminConf: kamajiKubeconfig,
+			keyAdminSvc:  kamajiSvcKubeconfig,
+		}),
+	)
+	r.cfg.Providers = mustPresets(t, "kamaji")
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	list, err := c.CoreV1().Secrets(testTargetNS).List(context.Background(), metaV1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("two keys on one Secret produced %d registrations, want 1", len(list.Items))
+	}
+	// secretValue, not Data: the fake does not merge StringData the way a real
+	// apiserver does, so a freshly CREATED Secret reads empty out of Data alone.
+	if got := secretValue(&list.Items[0], "server"); got != "https://192.168.1.195:6443" {
+		t.Errorf("server = %q, want admin.conf's address; the first key that parses wins", got)
+	}
+}
+
+// A repeated key is a typo in a values file. Every present key is now its own
+// candidate, so a duplicate would parse the same bytes twice and report the same
+// failure twice while the operator learned nothing.
+func TestDuplicateSecretKeysInOneProviderAreRejected(t *testing.T) {
+	cfg := testConfig()
+	cfg.Providers = []Provider{{
+		Name:              "mytool",
+		SecretNamePattern: "mytool-*",
+		SecretKeys:        []string{keyAdminConf, keyAdminSvc, keyAdminConf},
+	}}
+	if err := cfg.Validate(); err == nil {
+		t.Error("a duplicated secret key was accepted")
 	}
 }

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -1143,6 +1143,9 @@ func TestConfigValidate(t *testing.T) {
 			c.Providers[0].Name = strings.Repeat("a", 64)
 		},
 		"prefix without slash": func(c *Config) { c.LabelPrefix = "example.com" },
+		// Negative would expire every demoted registration on sight, since
+		// time.Since is always greater than a negative duration.
+		"negative demoted TTL": func(c *Config) { c.DemotedTTL = -time.Second },
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := testConfig()

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -1143,6 +1143,12 @@ func TestConfigValidate(t *testing.T) {
 			c.Providers[0].Name = strings.Repeat("a", 64)
 		},
 		"prefix without slash": func(c *Config) { c.LabelPrefix = "example.com" },
+		// Under this prefix a source namespace could propagate
+		// argocd.argoproj.io/secret-type, which is not a reserved suffix, and the
+		// propagated labels are copied last so it would win.
+		"prefix that ArgoCD's own key falls under": func(c *Config) {
+			c.LabelPrefix = "argocd.argoproj.io/"
+		},
 		// Negative would expire every demoted registration on sight, since
 		// time.Since is always greater than a negative duration.
 		"negative demoted TTL": func(c *Config) { c.DemotedTTL = -time.Second },

--- a/internal/registrar/registrar_test.go
+++ b/internal/registrar/registrar_test.go
@@ -33,6 +33,10 @@ const (
 	// testServer is a placeholder endpoint for cases where the address itself is
 	// not what is being asserted.
 	testServer = "https://x"
+	// resourceSecrets names the resource in fake-clientset reactors.
+	resourceSecrets = "secrets"
+	// testHour spaces fixture namespaces apart when age decides a contested name.
+	testHour = time.Hour
 
 	// Kamaji's two kubeconfig keys. Named because the multi-key tests repeat them
 	// and because which of the two wins is itself the assertion.
@@ -159,7 +163,7 @@ func TestTransientSecretListErrorDoesNotDeregisterAnything(t *testing.T) {
 		managedNS(testNS, "a"), kubeconfigSecret(testNS, "k3k-a-kubeconfig"), registeredSecret("a", testNS),
 		managedNS("k3k-b", "b"), kubeconfigSecret("k3k-b", "k3k-b-kubeconfig"), registeredSecret("b", "k3k-b"),
 	)
-	c.PrependReactor("list", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("list", resourceSecrets, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.GetNamespace() != testTargetNS {
 			return true, nil, apiErrors.NewInternalError(io.ErrUnexpectedEOF)
 		}
@@ -225,9 +229,9 @@ func TestCollectNeverTouchesUnlabelledSecrets(t *testing.T) {
 // One undeletable Secret must not stall GC for every other cluster.
 func TestCollectContinuesPastDeleteErrors(t *testing.T) {
 	r, c := newTestRegistrar(registeredSecret("a", testNS), registeredSecret("b", "k3k-b"))
-	c.PrependReactor("delete", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("delete", resourceSecrets, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.(k8stesting.DeleteAction).GetName() == "cluster-a" {
-			return true, nil, apiErrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "cluster-a", io.ErrUnexpectedEOF)
+			return true, nil, apiErrors.NewForbidden(schema.GroupResource{Resource: resourceSecrets}, "cluster-a", io.ErrUnexpectedEOF)
 		}
 		return false, nil, nil
 	})
@@ -667,9 +671,9 @@ func TestConflictedLoserDoesNotStrandTheWinnersSecret(t *testing.T) {
 // worker reconciles at a time.
 func TestCreateRaceReturnsConflict(t *testing.T) {
 	r, c := newTestRegistrar(managedNS(testSourceNS, "a"), kubeconfigSecret(testSourceNS, "k3k-a-kubeconfig"))
-	c.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("create", resourceSecrets, func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apiErrors.NewAlreadyExists(
-			schema.GroupResource{Resource: "secrets"}, "cluster-a")
+			schema.GroupResource{Resource: resourceSecrets}, "cluster-a")
 	})
 
 	err := r.apply(context.Background(), child{
@@ -721,9 +725,9 @@ func TestReconcileReturnsNilOnConflictButErrorsOnRealFailure(t *testing.T) {
 	}
 
 	r, c := newFixture()
-	c.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("create", resourceSecrets, func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apiErrors.NewForbidden(
-			schema.GroupResource{Resource: "secrets"}, "cluster-b", io.ErrUnexpectedEOF)
+			schema.GroupResource{Resource: resourceSecrets}, "cluster-b", io.ErrUnexpectedEOF)
 	})
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Error("a forbidden write was not reported")
@@ -855,7 +859,7 @@ func TestDemotionIsNotRepeated(t *testing.T) {
 	}
 	first := getSecret(t, c, "cluster-a").Labels[StaleSinceLabel(testPrefix)]
 
-	c.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("update", resourceSecrets, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		if action.(k8stesting.UpdateAction).GetObject().(*coreV1.Secret).Name == "cluster-a" {
 			t.Error("cluster-a was demoted a second time")
 		}
@@ -956,7 +960,7 @@ func TestOrphanDeleteIsPreconditionedOnTheSecretUID(t *testing.T) {
 	r, c := newTestRegistrar(orphan)
 	var gotUID types.UID
 	var sawDelete bool
-	c.PrependReactor("delete", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	c.PrependReactor("delete", resourceSecrets, func(action k8stesting.Action) (bool, runtime.Object, error) {
 		sawDelete = true
 		if pre := action.(k8stesting.DeleteActionImpl).DeleteOptions.Preconditions; pre != nil && pre.UID != nil {
 			gotUID = *pre.UID
@@ -1354,9 +1358,9 @@ func TestEveryRefusalCarriesItsOwnReason(t *testing.T) {
 			want: conflictCreateRace,
 			build: func(*testing.T) (*Registrar, child) {
 				r, c := newTestRegistrar(managedNS(testSourceNS, "a"))
-				c.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+				c.PrependReactor("create", resourceSecrets, func(k8stesting.Action) (bool, runtime.Object, error) {
 					return true, nil, apiErrors.NewAlreadyExists(
-						schema.GroupResource{Resource: "secrets"}, "cluster-a")
+						schema.GroupResource{Resource: resourceSecrets}, "cluster-a")
 				})
 				return r, child{cluster: "a", namespace: testSourceNS, server: testServer, config: "{}"}
 			},

--- a/internal/registrar/ttl_test.go
+++ b/internal/registrar/ttl_test.go
@@ -1,0 +1,244 @@
+package registrar
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// demotedSecret is what a rename leaves behind: hidden from ArgoCD, kept, and
+// stamped with when it happened.
+//
+// The stamp is passed in rather than taken from the clock, so the tests below
+// need no injectable time source. `stale` is the age, not the timestamp.
+func demotedSecret(cluster, srcNS string, stale time.Duration) *coreV1.Secret {
+	s := registeredSecret(cluster, srcNS)
+	s.UID = types.UID("uid-" + s.Name)
+	s.ResourceVersion = "1000"
+	delete(s.Labels, argoSecretTypeLabel)
+	s.Labels[OrphanedSecretTypeLabel(testPrefix)] = argoSecretTypeValue
+	s.Labels[SupersededByLabel(testPrefix)] = "cluster-new"
+	s.Labels[StaleSinceLabel(testPrefix)] = time.Now().UTC().Add(-stale).Format(staleSinceFormat)
+	return s
+}
+
+// renamedTo builds the state after a namespace has re-registered under a new
+// name: the live registration, the demoted one, and the namespace itself.
+func renamedTo(t *testing.T, newCluster string, old *coreV1.Secret, ttl time.Duration) (*Registrar, *fake.Clientset) {
+	t.Helper()
+	r, c := newTestRegistrar(
+		managedNS(testNS, newCluster),
+		kubeconfigSecret(testNS, "k3k-a-kubeconfig"),
+		old,
+	)
+	r.cfg.DemotedTTL = ttl
+	return r, c
+}
+
+// A demoted registration is deleted once it has been superseded for longer than
+// the TTL.
+func TestDemotedRegistrationIsDeletedOnceItsTTLExpires(t *testing.T) {
+	r, c := renamedTo(t, "new", demotedSecret("old", testNS, 48*time.Hour), 24*time.Hour)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if secretExists(t, c, "cluster-old") {
+		t.Error("a demoted registration outlived its TTL and was kept")
+	}
+	if !secretExists(t, c, "cluster-new") {
+		t.Error("the live registration was collected along with the expired one")
+	}
+}
+
+// ...and kept while it has not.
+//
+// Without this, deleting the TTL comparison outright still passes the test
+// above: "always expire" and "expire when old" are indistinguishable from one
+// direction.
+func TestDemotedRegistrationIsKeptWhileItsTTLHasNotExpired(t *testing.T) {
+	r, c := renamedTo(t, "new", demotedSecret("old", testNS, time.Hour), 24*time.Hour)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("a demoted registration was deleted an hour into a 24h TTL")
+	}
+}
+
+// An unreadable stamp must never expire.
+//
+// time.Parse returns the ZERO time on failure. An ignored error therefore reads
+// as the year 1, making every demoted registration about two thousand years old,
+// and the first reconcile after upgrading would delete every one of them across
+// the fleet. This is the single most expensive mistake available in this change.
+func TestAnUnparseableStaleSinceStampNeverExpires(t *testing.T) {
+	old := demotedSecret("old", testNS, 48*time.Hour)
+	old.Labels[StaleSinceLabel(testPrefix)] = "not-a-timestamp"
+	// One nanosecond: if the stamp were believed at all, this expires instantly.
+	r, c := renamedTo(t, "new", old, time.Nanosecond)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("an unreadable stale-since stamp was treated as ancient and deleted")
+	}
+}
+
+// A missing stamp must never expire either.
+//
+// Registrations demoted before the stamp existed carry no such label, and
+// absence is not evidence of age. Same rule as
+// TestRegistrationsWithoutARecordedUIDAreNeverCollectedAsStale.
+//
+// Two guards cover this, so removing either alone still passes: an empty stamp
+// also fails to parse. That is defence in depth rather than a discriminating
+// test, and it is worth knowing which this is.
+func TestADemotedRegistrationWithoutAStaleSinceStampNeverExpires(t *testing.T) {
+	old := demotedSecret("old", testNS, 48*time.Hour)
+	delete(old.Labels, StaleSinceLabel(testPrefix))
+	r, c := renamedTo(t, "new", old, time.Nanosecond)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("a registration with no stale-since stamp was expired")
+	}
+}
+
+// Unset means never, which is what every existing installation gets on upgrade.
+func TestTheDemotedTTLIsDisabledByDefault(t *testing.T) {
+	if testConfig().DemotedTTL != 0 {
+		t.Fatal("this test is meaningless unless the default is zero")
+	}
+	r, c := renamedTo(t, "new", demotedSecret("old", testNS, 10000*time.Hour), 0)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("a demoted registration was deleted with no TTL configured")
+	}
+}
+
+// A terminating namespace must not expire anything.
+//
+// It reaches collection with applied == "", and a finalizer can still abort the
+// deletion and bring the namespace back. Demotion is survivable there because it
+// is reversible; a delete is not. This is what pins the TTL check BELOW that
+// guard rather than above it.
+func TestATerminatingNamespaceDoesNotExpireItsDemotedRegistrations(t *testing.T) {
+	ns := managedNS(testNS, "new")
+	now := metaV1.NewTime(time.Now())
+	ns.DeletionTimestamp = &now
+	ns.Finalizers = []string{"example.com/pending"}
+
+	r, c := newTestRegistrar(ns, demotedSecret("old", testNS, 48*time.Hour))
+	r.cfg.DemotedTTL = time.Nanosecond
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("a demoted registration was expired while its namespace was still terminating")
+	}
+}
+
+// The opt-out covers expiry too, which is now a third way a registration can be
+// removed.
+//
+// Near-tautological as written, since the prune check sits above the demoted
+// branch: the mutation it guards against is someone reordering the two.
+func TestPruneDisabledSurvivesExpiry(t *testing.T) {
+	old := demotedSecret("old", testNS, 48*time.Hour)
+	old.Labels[PruneLabel(testPrefix)] = PruneDisabled
+	r, c := renamedTo(t, "new", old, time.Nanosecond)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-old") {
+		t.Error("an opted-out registration was expired")
+	}
+}
+
+// The TTL delete must be preconditioned on the exact object that was read.
+//
+// UID alone is not enough here, unlike the orphan path: a reverted rename goes
+// through apply's read-modify-write, which PRESERVES the UID. Only the
+// resourceVersion moves, so only it can tell "still the demoted object I decided
+// about" from "restored a moment ago".
+//
+// The fake ignores DeleteOptions entirely and never populates resourceVersion,
+// so this needs a capture reactor and a fixture that sets one; without both it
+// would compare "" to "" and pass with no precondition at all.
+func TestTTLDeletionIsPreconditionedOnTheSecretsIdentity(t *testing.T) {
+	old := demotedSecret("old", testNS, 48*time.Hour)
+	if old.UID == "" || old.ResourceVersion == "" {
+		t.Fatal("the fixture must carry both, or the assertions below are vacuous")
+	}
+	r, c := renamedTo(t, "new", old, 24*time.Hour)
+
+	var gotUID types.UID
+	var gotRV string
+	var saw bool
+	c.PrependReactor("delete", resourceSecrets, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		del, ok := action.(k8stesting.DeleteActionImpl)
+		if !ok || del.GetName() != "cluster-old" {
+			return false, nil, nil
+		}
+		saw = true
+		if pre := del.DeleteOptions.Preconditions; pre != nil {
+			if pre.UID != nil {
+				gotUID = *pre.UID
+			}
+			if pre.ResourceVersion != nil {
+				gotRV = *pre.ResourceVersion
+			}
+		}
+		return false, nil, nil
+	})
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !saw {
+		t.Fatal("the expired registration was never deleted")
+	}
+	if gotUID != old.UID {
+		t.Errorf("delete precondition UID = %q, want %q", gotUID, old.UID)
+	}
+	if gotRV != old.ResourceVersion {
+		t.Errorf("delete precondition resourceVersion = %q, want %q; a rename reverted "+
+			"in the race window would be deleted anyway", gotRV, old.ResourceVersion)
+	}
+}
+
+// Reverting the rename beats an expiring TTL.
+//
+// The live registration is checked before anything else in the loop, so the
+// restored Secret is skipped as "the one we just applied" rather than considered
+// for expiry. Moving the TTL check above that skip would delete the cluster that
+// is currently registered.
+func TestARevertedRenameBeatsAnExpiringTTL(t *testing.T) {
+	// Same name the namespace is now registering under, and ancient.
+	old := demotedSecret("a", testNS, 10000*time.Hour)
+	r, c := renamedTo(t, "a", old, time.Nanosecond)
+
+	if _, err := r.ReconcileOne(context.Background(), testNS); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !secretExists(t, c, "cluster-a") {
+		t.Error("the registration this namespace is currently using was expired")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,13 +2,19 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	"github.com/pcanilho/argocd-cluster-registrar/cmd"
 )
 
 func main() {
+	// No message and no logger. cobra prints the error itself (SilenceErrors is
+	// false, deliberately), so wrapping it here printed every failure twice: once
+	// as logfmt on stdout like the rest of the process, once with the standard
+	// library's date prefix on stderr. The wording was inherited from
+	// vcluster-argocd-exporter too, so a flag validation error caught before
+	// anything touched a cluster was reported as a failure to export clusters.
 	if err := cmd.Execute(); err != nil {
-		log.Fatalf("failed to export cluster(s). error: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## What lands

**Metrics, off by default.** Four series, every label value a compile-time constant. `conflicts_total{reason}` is the point: a contested cluster name persists until a human resolves it, and until now the only signal was a log line. Counters are published at zero from startup, because an absent series makes `increase(...[15m]) > 0` unevaluable rather than false.

Which cluster is contested stays in the log line and is not coming to the labels. Those values are tenant-controlled, so as labels they are unbounded cardinality on the one path that exists because somebody may be acting in bad faith, and a per-conflict gauge could never be cleared: a deleted claimant namespace takes the `NotFound` branch and never reaches the code that would zero it.

Cost was one line in `go.mod`. `client_golang` was already linked through the metrics server controller-runtime always builds. `pkg/metrics/filters` is still not imported, and CI now asserts `k8s.io/apiserver` stays out of the binary.

**`demotedTTL`, off by default.** Renamed clusters left demoted registrations that accumulated until their namespace died, holding the old cluster name the whole time. The TTL bounds that and frees the name. Opt-in, because it is equally a deadline on reverting a rename.

Placed below the `applied == ""` guard in `collectOne`, not above it: that guard exists because a terminating namespace can come back if a finalizer aborts, which a reversible demotion survives and a delete does not.

**B1, key-level fallthrough.** Discovery stopped at the first key a `Secret` carried, so a half-written Kamaji `admin.conf` put `admin.svc` out of reach and stranded the namespace, while `Provider.SecretKeys` documented its keys as "tried in order". Both keys normally parse, so `admin.conf` still wins on a healthy install; this makes the declared order real.

**A test drives a real manager.** The startup seeder had no coverage anywhere. Removing it leaves every other test passing while a registration orphaned during downtime survives forever with no symptom.

## Also

`buildOptions` extracted from `RunE`, which fixes the `--dry-run` de-escalation writing back into the `--leader-elect` flag variable, and makes "every flag reaches the option it configures" assertable without a cluster.

The README no longer restates the chart's values. Nine keys were documented twice while twenty-three existed. Architecture notes moved to `docs/architecture.md`.

## Verification

Every behaviour change was mutation-tested: the guard removed or inverted, and the named test confirmed to fail. Two mutations that "survived" turned out to be invalid, one because it did not compile, and were redone. Notable ones:

- ignoring the `time.Parse` error on `stale-since` gives the zero time, ages every demoted registration by two millennia, and deletes the fleet on first upgrade
- dropping the `""` to `"0"` metrics normalisation opens an unauthenticated port on installs that never asked
- restoring the `break` in the key loop, and dropping `discoverOne`'s `break` so the last usable candidate wins rather than the first
- breaking the seeder, which is invisible to the entire rest of the suite

Local gate green: `go test -race -cover`, `golangci-lint`, `gosec`, `go mod tidy` clean, `helm lint`/`kubeconform` across the value matrix, `goreleaser --snapshot`. envtest run against a real apiserver at k8s 1.35.0.

CI additions: the `k8s.io/apiserver` guard, chart render assertions for metrics and `demotedTTL` (`0s` is a truthy string in a Go template while `0` is a falsy int, which rendered opposite results for the same intent), an envtest step that asserts the case actually ran rather than skipped, and two kind steps covering the seeder and label-removal against real RBAC.
